### PR TITLE
COMP: Fix configure failure due to spaces in project name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13.4)
 
-project(CT Lung Analyzer CT Analyzer)
+project(SlicerCTLungAnalyzer)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information


### PR DESCRIPTION
@rbumm This fixes the following configure errors that were a result of spaces used in the CMakeLists project name.

```cmake
Selecting Windows SDK version 10.0.18362.0 to target Windows 10.0.19042.
CMake Error: Could not find cmake module file: CMakeDetermineLungCompiler.cmake
CMake Error: Could not find cmake module file: C:/D/SlicerCTLungAnalyzer-bin/CMakeFiles/3.18.4/CMakeLungCompiler.cmake
CMake Error: Could not find cmake module file: CMakeDetermineAnalyzerCompiler.cmake
CMake Error: Could not find cmake module file: C:/D/SlicerCTLungAnalyzer-bin/CMakeFiles/3.18.4/CMakeAnalyzerCompiler.cmake
CMake Error: Could not find cmake module file: CMakeDetermineCTCompiler.cmake
CMake Error: Could not find cmake module file: C:/D/SlicerCTLungAnalyzer-bin/CMakeFiles/3.18.4/CMakeCTCompiler.cmake
CMake Error at CMakeLists.txt:3 (project):
  No CMAKE_Lung_COMPILER could be found.



CMake Error: Could not find cmake module file: CMakeLungInformation.cmake
CMake Error at CMakeLists.txt:3 (project):
  No CMAKE_Analyzer_COMPILER could be found.



CMake Error: Could not find cmake module file: CMakeAnalyzerInformation.cmake
CMake Error at CMakeLists.txt:3 (project):
  No CMAKE_CT_COMPILER could be found.



CMake Error: Could not find cmake module file: CMakeCTInformation.cmake
CMake Error at CMakeLists.txt:3 (project):
  No CMAKE_Analyzer_COMPILER could be found.



CMake Error: Could not find cmake module file: CMakeAnalyzerInformation.cmake
Configuring incomplete, errors occurred!
```