### PR TITLE
Cleanup and real-time 2D/3D thresholding preview

### DIFF
--- a/CTLungAnalyzer/CTLungAnalyzer.py
+++ b/CTLungAnalyzer/CTLungAnalyzer.py
@@ -10,378 +10,450 @@ from slicer.util import VTKObservationMixin
 #
 
 class CTLungAnalyzer(ScriptedLoadableModule):
-  """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
-  """
+    """Uses ScriptedLoadableModule base class, available at:
+    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+    """
 
-  def __init__(self, parent):
-    ScriptedLoadableModule.__init__(self, parent)
-    self.parent.title = "Lung CT Analyzer"  # TODO: make this more human readable by adding spaces
-    self.parent.categories = ["Chest Imaging Platform"]  # TODO: set categories (folders where the module shows up in the module selector)
-    self.parent.dependencies = []  # TODO: add here list of module names that this module requires
-    self.parent.contributors = ["Rudolf Bumm (KSGR Switzerland)"]  # TODO: replace with "Firstname Lastname (Organization)"
-    # TODO: update with short description of the module and a link to online module documentation
-    self.parent.helpText = """
+    def __init__(self, parent):
+        ScriptedLoadableModule.__init__(self, parent)
+        self.parent.title = "Lung CT Analyzer"
+        self.parent.categories = ["Chest Imaging Platform"]
+        self.parent.dependencies = []  # TODO: add here list of module names that this module requires
+        self.parent.contributors = ["Rudolf Bumm (KSGR Switzerland)"]
+        self.parent.helpText = """
 The CT Lung Analyzer is a 3D Slicer extension for segmentation and spatial reconstruction of infiltrated and collapsed areas in chest CT examinations.
 See more information in <a href="https://github.com/rbumm/SlicerCTLungAnalyzer">module documentation</a>.
 """
-    # TODO: replace with organization, grant and thanks
-    self.parent.acknowledgementText = """
-This file was originally developed by Rudolf Bumm, Kantonsspital Graubünden, Switzerland. Parts of this code were inspired by a code snippet (https://gist.github.com/lassoan/5ad51c89521d3cd9c5faf65767506b37) of Andras Lasso, PerkLab. 
+        self.parent.acknowledgementText = """
+This file was originally developed by Rudolf Bumm, Kantonsspital Graubünden, Switzerland. Parts of this code were inspired by a code snippet (https://gist.github.com/lassoan/5ad51c89521d3cd9c5faf65767506b37) of Andras Lasso, PerkLab.
 """
 
-    # Additional initialization step after application startup is complete
-    slicer.app.connect("startupCompleted()", registerSampleData)
+        # Additional initialization step after application startup is complete
+        slicer.app.connect("startupCompleted()", registerSampleData)
 
 #
 # Register sample data sets in Sample Data module
 #
 
 def registerSampleData():
-  """
-  Add data sets to Sample Data module.
-  """
-  # It is always recommended to provide sample data for users to make it easy to try the module,
-  # but if no sample data is available then this method (and associated startupCompeted signal connection) can be removed.
+    """
+    Add data sets to Sample Data module.
+    """
+    # It is always recommended to provide sample data for users to make it easy to try the module,
+    # but if no sample data is available then this method (and associated startupCompeted signal connection) can be removed.
 
-  import SampleData
-  iconsPath = os.path.join(os.path.dirname(__file__), 'Resources/Icons')
+    import SampleData
+    iconsPath = os.path.join(os.path.dirname(__file__), 'Resources/Icons')
 
-  # To ensure that the source code repository remains small (can be downloaded and installed quickly)
-  # it is recommended to store data sets that are larger than a few MB in a Github release.
+    # To ensure that the source code repository remains small (can be downloaded and installed quickly)
+    # it is recommended to store data sets that are larger than a few MB in a Github release.
 
-  # load demo chest CT
-  
-  SampleData.SampleDataLogic.registerCustomSampleDataSource( 
-      category="Lung", 
-      sampleName='DemoChestCT',
-      uris='http://scientific-networks.com/slicerdata/LungCTAnalyzerChestCT.nrrd',
-      fileNames='DemoChestCT.nrrd',
-      nodeNames='DemoChestCT',
-      thumbnailFileName=os.path.join(iconsPath, 'DemoChestCT.png'),
-      loadFileType='VolumeFile',
-      checksums='SHA256:9bb74f4383bce0ced80243916e785ce564cc2c8f535e8273da8a04f80dff4287'
-      )
-  SampleData.SampleDataLogic.registerCustomSampleDataSource( 
-      category="Lung", 
-      sampleName='DemoLungMasks',
-      uris='http://scientific-networks.com/slicerdata/LungCTAnalyzerMaskSegmentation.seg.nrrd',
-      fileNames='DemoLungMasks.seg.nrrd',
-      nodeNames='DemoLungMasks',
-      thumbnailFileName=os.path.join(iconsPath, 'DemoChestCT.png'),
-      loadFileType='SegmentationFile',
-      checksums='SHA256:76312929a5a17dc5188b268d0cd43dabe9f2e10c4496e71d56ee0be959077bc4'
-      )
-      
+    # load demo chest CT
+
+    SampleData.SampleDataLogic.registerCustomSampleDataSource(
+        category="Lung",
+        sampleName='DemoChestCT',
+        uris='http://scientific-networks.com/slicerdata/LungCTAnalyzerChestCT.nrrd',
+        fileNames='DemoChestCT.nrrd',
+        nodeNames='DemoChestCT',
+        thumbnailFileName=os.path.join(iconsPath, 'DemoChestCT.png'),
+        loadFileType='VolumeFile',
+        checksums='SHA256:9bb74f4383bce0ced80243916e785ce564cc2c8f535e8273da8a04f80dff4287'
+        )
+    SampleData.SampleDataLogic.registerCustomSampleDataSource(
+        category="Lung",
+        sampleName='DemoLungMasks',
+        uris='http://scientific-networks.com/slicerdata/LungCTAnalyzerMaskSegmentation.seg.nrrd',
+        fileNames='DemoLungMasks.seg.nrrd',
+        nodeNames='DemoLungMasks',
+        thumbnailFileName=os.path.join(iconsPath, 'DemoChestCT.png'),
+        loadFileType='SegmentationFile',
+        checksums='SHA256:76312929a5a17dc5188b268d0cd43dabe9f2e10c4496e71d56ee0be959077bc4'
+        )
+
 #
 # CTLungAnalyzerWidget
 #
 
 class CTLungAnalyzerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
-  """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
-  """
-  
-
-  
-  def __init__(self, parent=None):
-    """
-    Called when the user opens the module the first time and the widget is initialized.
-    """
-    ScriptedLoadableModuleWidget.__init__(self, parent)
-    VTKObservationMixin.__init__(self)  # needed for parameter node observation
-    self.logic = None
-    self._parameterNode = None
-    self._updatingGUIFromParameterNode = False
-    
-
-  def setup(self):
-    """
-    Called when the user opens the module the first time and the widget is initialized.
-    """
-    ScriptedLoadableModuleWidget.setup(self)
-
-    # Load widget from .ui file (created by Qt Designer).
-    # Additional widgets can be instantiated manually and added to self.layout.
-    uiWidget = slicer.util.loadUI(self.resourcePath('UI/CTLungAnalyzer.ui'))
-    self.layout.addWidget(uiWidget)
-    self.ui = slicer.util.childWidgetVariables(uiWidget)
-
-    # Set scene in MRML widgets. Make sure that in Qt designer the top-level qMRMLWidget's
-    # "mrmlSceneChanged(vtkMRMLScene*)" signal in is connected to each MRML widget's.
-    # "setMRMLScene(vtkMRMLScene*)" slot.
-    uiWidget.setMRMLScene(slicer.mrmlScene)
-
-    # Create logic class. Logic implements all computations that should be possible to run
-    # in batch mode, without a graphical user interface.
-    self.logic = CTLungAnalyzerLogic()
-
-    # Connections
-
-    # These connections ensure that we update parameter node when scene is closed
-    self.addObserver(slicer.mrmlScene, slicer.mrmlScene.StartCloseEvent, self.onSceneStartClose)
-    self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
-
-    
-    # These connections ensure that whenever user changes some settings on the GUI, that is saved in the MRML scene
-    # (in the selected parameter node).
-    self.ui.inputVolumeSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
-    self.ui.rightLungMaskSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
-    self.ui.leftLungMaskSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
-
-    # Buttons
-    self.ui.applyButton.connect('clicked(bool)', self.onApplyButton)
-    self.ui.restoreDefaultsButton.connect('clicked(bool)', self.onRestoreDefaultsButton)
-    self.ui.saveThresholdsButton.connect('clicked(bool)', self.onSaveThresholdsButton)
-    self.ui.loadThresholdsButton.connect('clicked(bool)', self.onLoadThresholdsButton)
-    self.ui.segmentsOnOffButton.connect('clicked(bool)', self.onSegmentsOnOffButton)
-    self.ui.dwnlCOVIDDataButton.connect('clicked(bool)', self.ondwnlCOVIDDataButton)
-    
-
-    #Range sliders
-    self.ui.BullaRangeWidget.connect( 'valuesChanged(double,double)', self.onBullaRangeWidgetChanged )
-    self.ui.VentilatedRangeWidget.connect( 'valuesChanged(double,double)', self.onVentilatedRangeWidgetChanged )
-    self.ui.InfiltratedRangeWidget.connect( 'valuesChanged(double,double)', self.onInfiltratedRangeWidgetChanged )
-    self.ui.CollapsedRangeWidget.connect( 'valuesChanged(double,double)', self.onCollapsedRangeWidgetChanged )
-    self.ui.VesselsRangeWidget.connect( 'valuesChanged(double,double)', self.onVesselsRangeWidgetChanged )
-
-    # Make sure parameter node is initialized (needed for module reload)
-    self.initializeParameterNode()
-    self.initThresholds()
-    seg_visible = True
-
-
-  def cleanup(self):
-    """
-    Called when the application closes and the module widget is destroyed.
-    """
-    self.removeObservers()
-
-  def enter(self):
-    """
-    Called each time the user opens this module.
-    """
-    # Make sure parameter node exists and observed
-    self.initializeParameterNode()
-
-  def exit(self):
-    """
-    Called each time the user opens a different module.
-    """
-    # Do not react to parameter node changes (GUI wlil be updated when the user enters into the module)
-    self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
-
-  def onSceneStartClose(self, caller, event):
-    """
-    Called just before the scene is closed.
-    """
-    # Parameter node will be reset, do not use it anymore
-    self.setParameterNode(None)
-
-  def onSceneEndClose(self, caller, event):
-    """
-    Called just after the scene is closed.
-    """
-    # If this module is shown while the scene is closed then recreate a new parameter node immediately
-    if self.parent.isEntered:
-      self.initializeParameterNode()
-
-  def initializeParameterNode(self):
-    """
-    Ensure parameter node exists and observed.
-    """
-    # Parameter node stores all user choices in parameter values, node selections, etc.
-    # so that when the scene is saved and reloaded, these settings are restored.
-
-    self.setParameterNode(self.logic.getParameterNode())
-
-    # Select default input nodes if nothing is selected yet to save a few clicks for the user
-    if not self._parameterNode.GetNodeReference("InputVolume"):
-      firstVolumeNode = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLScalarVolumeNode")
-      if firstVolumeNode:
-        self._parameterNode.SetNodeReferenceID("InputVolume", firstVolumeNode.GetID())
-   # Select default input nodes if nothing is selected yet to save a few clicks for the user
-
-
-  def setParameterNode(self, inputParameterNode):
-    """
-    Set and observe parameter node.
-    Observation is needed because when the parameter node is changed then the GUI must be updated immediately.
+    """Uses ScriptedLoadableModuleWidget base class, available at:
+    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
-    if inputParameterNode:
-      self.logic.setDefaultParameters(inputParameterNode)
+    def __init__(self, parent=None):
+        """
+        Called when the user opens the module the first time and the widget is initialized.
+        """
+        ScriptedLoadableModuleWidget.__init__(self, parent)
+        VTKObservationMixin.__init__(self)  # needed for parameter node observation
+        self.logic = None
+        self._parameterNode = None
+        self._updatingGUIFromParameterNode = False
 
-    # Unobserve previously selected parameter node and add an observer to the newly selected.
-    # Changes of parameter node are observed so that whenever parameters are changed by a script or any other module
-    # those are reflected immediately in the GUI.
-    if self._parameterNode is not None:
-      self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
-    self._parameterNode = inputParameterNode
-    if self._parameterNode is not None:
-      self.addObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
+    def setup(self):
+        """
+        Called when the user opens the module the first time and the widget is initialized.
+        """
+        ScriptedLoadableModuleWidget.setup(self)
 
-    # Initial GUI update
-    self.updateGUIFromParameterNode()
+        # Load widget from .ui file (created by Qt Designer).
+        # Additional widgets can be instantiated manually and added to self.layout.
+        uiWidget = slicer.util.loadUI(self.resourcePath('UI/CTLungAnalyzer.ui'))
+        self.layout.addWidget(uiWidget)
+        self.ui = slicer.util.childWidgetVariables(uiWidget)
 
-  def updateGUIFromParameterNode(self, caller=None, event=None):
-    """
-    This method is called whenever parameter node is changed.
-    The module GUI is updated to show the current state of the parameter node.
-    """
+        # Set scene in MRML widgets. Make sure that in Qt designer the top-level qMRMLWidget's
+        # "mrmlSceneChanged(vtkMRMLScene*)" signal in is connected to each MRML widget's.
+        # "setMRMLScene(vtkMRMLScene*)" slot.
+        uiWidget.setMRMLScene(slicer.mrmlScene)
 
-    if self._parameterNode is None or self._updatingGUIFromParameterNode:
-      return
+        # Create logic class. Logic implements all computations that should be possible to run
+        # in batch mode, without a graphical user interface.
+        self.logic = CTLungAnalyzerLogic()
 
-    # Make sure GUI changes do not call updateParameterNodeFromGUI (it could cause infinite loop)
-    self._updatingGUIFromParameterNode = True
+        self.volumeRenderingPropertyUpdateTimer = qt.QTimer()
+        self.volumeRenderingPropertyUpdateTimer.setInterval(1000)
+        self.volumeRenderingPropertyUpdateTimer.setSingleShot(True)
+        self.volumeRenderingPropertyUpdateTimer.timeout.connect(self.updateVolumeRenderingProperty)
 
-    # Update node selectors and sliders
-    self.ui.inputVolumeSelector.setCurrentNode(self._parameterNode.GetNodeReference("InputVolume"))
-    self.ui.rightLungMaskSelector.setCurrentNode(self._parameterNode.GetNodeReference("RightLungMaskNode"))
-    self.ui.leftLungMaskSelector.setCurrentNode(self._parameterNode.GetNodeReference("LeftLungMaskNode"))
+        # Connections
 
- 
-    # Update buttons states and tooltips
-    if self._parameterNode.GetNodeReference("InputVolume") and self._parameterNode.GetNodeReference("RightLungMaskNode") and self._parameterNode.GetNodeReference("LeftLungMaskNode"):
-    #if self._parameterNode.GetNodeReference("InputVolume"):
-      self.ui.applyButton.toolTip = "Compute input volume"
-      self.ui.applyButton.enabled = True
-    else:
-      self.ui.applyButton.toolTip = "Select input volume and right and left lung mask"
-      self.ui.applyButton.enabled = False
+        # These connections ensure that we update parameter node when scene is closed
+        self.addObserver(slicer.mrmlScene, slicer.mrmlScene.StartCloseEvent, self.onSceneStartClose)
+        self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
 
-    # All the GUI updates are done
-    self._updatingGUIFromParameterNode = False
+        # These connections ensure that whenever user changes some settings on the GUI, that is saved in the MRML scene
+        # (in the selected parameter node).
 
-  def updateParameterNodeFromGUI(self, caller=None, event=None):
-    """
-    This method is called when the user makes any change in the GUI.
-    The changes are saved into the parameter node (so that they are restored when the scene is saved and loaded).
-    """
+        # Input image and segmentation
+        self.ui.inputVolumeSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
+        self.ui.inputSegmentationSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.onInputSegmentationSelected)
+        self.ui.rightLungMaskSelector.connect("currentSegmentChanged(QString)", self.updateParameterNodeFromGUI)
+        self.ui.leftLungMaskSelector.connect("currentSegmentChanged(QString)", self.updateParameterNodeFromGUI)
+
+        # Output options
+        self.ui.generateStatisticsCheckBox.connect('toggled(bool)', self.updateParameterNodeFromGUI)
+        self.ui.rightLungMaskedVolumeSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
+        self.ui.leftLungMaskedVolumeSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
+        self.ui.outputResultsTableSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
+        self.ui.volumeRenderingPropertyNodeSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
+        self.ui.includeCovidEvaluationCheckBox.connect('toggled(bool)', self.updateParameterNodeFromGUI)
+        self.ui.outputCovidResultsTableSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
+
+        # Thresholds
+        self.ui.BullaRangeWidget.connect('valuesChanged(double,double)', self.onBullaRangeWidgetChanged)
+        self.ui.VentilatedRangeWidget.connect('valuesChanged(double,double)', self.onVentilatedRangeWidgetChanged)
+        self.ui.InfiltratedRangeWidget.connect('valuesChanged(double,double)', self.onInfiltratedRangeWidgetChanged)
+        self.ui.CollapsedRangeWidget.connect('valuesChanged(double,double)', self.onCollapsedRangeWidgetChanged)
+        self.ui.VesselsRangeWidget.connect('valuesChanged(double,double)', self.onVesselsRangeWidgetChanged)
+        self.ui.restoreDefaultsButton.connect('clicked(bool)', self.onRestoreDefaultsButton)
+        self.ui.saveThresholdsButton.connect('clicked(bool)', self.onSaveThresholdsButton)
+        self.ui.loadThresholdsButton.connect('clicked(bool)', self.onLoadThresholdsButton)
+
+        # Opacities
+        self.opacitySliders = {
+            "Emphysema": self.ui.bullaOpacityWidget,
+            "Ventilated": self.ui.ventilatedOpacityWidget,
+            "Infiltration": self.ui.infiltratedOpacityWidget,
+            "Collapsed": self.ui.collapsedOpacityWidget,
+            "Vessels": self.ui.vesselsOpacityWidget,
+            }
+        for segment in self.opacitySliders:
+            self.opacitySliders[segment].connect('valueChanged(double)', self.updateVolumeRenderingPropertyFromGUI)
+
+        # Buttons
+        self.ui.downloadCovidDataButton.connect('clicked()', self.onDownloadCovidData)
+        self.ui.applyButton.connect('clicked()', self.onApplyButton)
+        self.ui.showResultsTablePushButton.connect('clicked()', self.onShowResultsTable)
+        self.ui.showCovidResultsTableButton.connect('clicked()', self.onShowCovidResultsTable)
+        self.ui.toggleSegmentsVisibility.connect('clicked()', self.onToggleSegmentsVisibility)
+        self.ui.showSegmentsIn3DPushButton.connect('clicked()', self.onShowSegmentsIn3D)
+        self.ui.toggleRightVolumeRenderingPushButton.connect('clicked()', lambda side='right': self.onToggleVolumeRendering(side))
+        self.ui.toggleLeftVolumeRenderingPushButton.connect('clicked()', lambda side='left': self.onToggleVolumeRendering(side))
+
+        # Make sure parameter node is initialized (needed for module reload)
+        self.initializeParameterNode()
+
+    def cleanup(self):
+        """
+        Called when the application closes and the module widget is destroyed.
+        """
+        self.removeObservers()
+
+    def enter(self):
+        """
+        Called each time the user opens this module.
+        """
+        # Make sure parameter node exists and observed
+        self.initializeParameterNode()
+
+    def exit(self):
+        """
+        Called each time the user opens a different module.
+        """
+        # Do not react to parameter node changes (GUI wlil be updated when the user enters into the module)
+        self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
+
+    def onSceneStartClose(self, caller, event):
+        """
+        Called just before the scene is closed.
+        """
+        # Parameter node will be reset, do not use it anymore
+        self.setParameterNode(None)
+
+    def onSceneEndClose(self, caller, event):
+        """
+        Called just after the scene is closed.
+        """
+        # If this module is shown while the scene is closed then recreate a new parameter node immediately
+        if self.parent.isEntered:
+            self.initializeParameterNode()
+
+    def findSegmentID(self, segmentationNode, segmentNameFragment):
+        segmentation = segmentationNode.GetSegmentation()
+        for segmentIndex in range(segmentation.GetNumberOfSegments()):
+            if segmentNameFragment.upper() in segmentation.GetNthSegment(segmentIndex).GetName().upper():
+                return segmentation.GetNthSegmentID(segmentIndex)
+        return None
+
+    def initializeParameterNode(self):
+        """
+        Ensure parameter node exists and observed.
+        """
+        # Parameter node stores all user choices in parameter values, node selections, etc.
+        # so that when the scene is saved and reloaded, these settings are restored.
+
+        self.setParameterNode(self.logic.getParameterNode())
+
+        # Select default input nodes if nothing is selected yet to save a few clicks for the user
+        if not self.logic.inputVolume:
+            firstVolumeNode = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLScalarVolumeNode")
+            if firstVolumeNode:
+                self.logic.inputVolume = firstVolumeNode
+        if not self.logic.inputSegmentation:
+            firstSegmentationNode = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLSegmentationNode")
+            if firstSegmentationNode:
+                self.logic.inputSegmentation = firstSegmentationNode
+                self.logic.rightLungMaskSegmentID = self.findSegmentID(firstSegmentationNode, "right")
+                self.logic.leftLungMaskSegmentID = self.findSegmentID(firstSegmentationNode, "left")
+
+    def setParameterNode(self, inputParameterNode):
+        """
+        Set and observe parameter node.
+        Observation is needed because when the parameter node is changed then the GUI must be updated immediately.
+        """
+
+        if inputParameterNode:
+          self.logic.setDefaultParameters(inputParameterNode)
+
+        # Unobserve previously selected parameter node and add an observer to the newly selected.
+        # Changes of parameter node are observed so that whenever parameters are changed by a script or any other module
+        # those are reflected immediately in the GUI.
+        if self._parameterNode is not None:
+            self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
+        self._parameterNode = inputParameterNode
+        if self._parameterNode is not None:
+            self.addObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
+
+        # Initial GUI update
+        self.updateGUIFromParameterNode()
+
+    def updateGUIFromParameterNode(self, caller=None, event=None):
+        """
+        This method is called whenever parameter node is changed.
+        The module GUI is updated to show the current state of the parameter node.
+        """
+
+        logging.info("updateGUIFromParameterNode")
+
+        if self._parameterNode is None or self._updatingGUIFromParameterNode:
+            return
+
+        # Make sure GUI changes do not call updateParameterNodeFromGUI (it could cause infinite loop)
+        self._updatingGUIFromParameterNode = True
+
+        # Update node selectors and sliders
+        self.ui.inputVolumeSelector.setCurrentNode(self.logic.inputVolume)
+        wasBlocked = self.ui.inputSegmentationSelector.blockSignals(True)
+        self.ui.inputSegmentationSelector.setCurrentNode(self.logic.inputSegmentation)
+        self.ui.rightLungMaskSelector.setCurrentNode(self.logic.inputSegmentation)
+        self.ui.leftLungMaskSelector.setCurrentNode(self.logic.inputSegmentation)
+        self.ui.inputSegmentationSelector.blockSignals(wasBlocked)
+        if self.logic.inputSegmentation:
+            self.ui.rightLungMaskSelector.setCurrentSegmentID(self.logic.rightLungMaskSegmentID)
+            self.ui.leftLungMaskSelector.setCurrentSegmentID(self.logic.leftLungMaskSegmentID)
+
+        thresholds = self.logic.thresholds
+        self.ui.BullaRangeWidget.minimumValue = thresholds['thresholdBullaLower']
+        self.ui.BullaRangeWidget.maximumValue = thresholds['thresholdBullaVentilated']
+        self.ui.VentilatedRangeWidget.minimumValue = thresholds['thresholdBullaVentilated']
+        self.ui.VentilatedRangeWidget.maximumValue = thresholds['thresholdVentilatedInfiltrated']
+        self.ui.InfiltratedRangeWidget.minimumValue = thresholds['thresholdVentilatedInfiltrated']
+        self.ui.InfiltratedRangeWidget.maximumValue = thresholds['thresholdInfiltratedCollapsed']
+        self.ui.CollapsedRangeWidget.minimumValue = thresholds['thresholdInfiltratedCollapsed']
+        self.ui.CollapsedRangeWidget.maximumValue = thresholds['thresholdCollapsedVessels']
+        self.ui.VesselsRangeWidget.minimumValue = thresholds['thresholdCollapsedVessels']
+        self.ui.VesselsRangeWidget.maximumValue = thresholds['thresholdVesselsUpper']
+
+        self.ui.rightLungMaskedVolumeSelector.setCurrentNode(self.logic.rightLungMaskedVolume)
+        self.ui.leftLungMaskedVolumeSelector.setCurrentNode(self.logic.leftLungMaskedVolume)
+        self.ui.outputResultsTableSelector.setCurrentNode(self.logic.resultsTable)
+        self.ui.volumeRenderingPropertyNodeSelector.setCurrentNode(self.logic.volumeRenderingPropertyNode)
+        self.ui.outputCovidResultsTableSelector.setCurrentNode(self.logic.covidResultsTable)
+
+        self.ui.generateStatisticsCheckBox.checked = self.logic.generateStatistics
+        self.ui.includeCovidEvaluationCheckBox.checked = self.logic.includeCovidEvaluation
+
+        # Update buttons states and tooltips
+        if (self.logic.inputVolume and self.logic.inputSegmentation
+            and self.logic.rightLungMaskSegmentID and self.logic.leftLungMaskSegmentID):
+            self.ui.applyButton.toolTip = "Compute results"
+            self.ui.applyButton.enabled = True
+        else:
+            self.ui.applyButton.toolTip = "Select input volume and right and left lung masks"
+            self.ui.applyButton.enabled = False
+
+        # If thresholds are changed then volume rendering needs an update, too
+        self.volumeRenderingPropertyUpdateTimer.start()
+
+        # All the GUI updates are done
+        self._updatingGUIFromParameterNode = False
+
+    def updateVolumeRenderingPropertyFromGUI(self):
+        self.volumeRenderingPropertyUpdateTimer.start()
+
+    def updateParameterNodeFromGUI(self, caller=None, event=None):
+        """
+        This method is called when the user makes any change in the GUI.
+        The changes are saved into the parameter node (so that they are restored when the scene is saved and loaded).
+        """
+
+        if self._parameterNode is None or self._updatingGUIFromParameterNode:
+            return
+
+        wasModified = self._parameterNode.StartModify()  # Modify all properties in a single batch
+
+        self.logic.inputVolume = self.ui.inputVolumeSelector.currentNode()
+        self.logic.inputSegmentation = self.ui.inputSegmentationSelector.currentNode()
+        self.logic.rightLungMaskSegmentID = self.ui.rightLungMaskSelector.currentSegmentID()
+        self.logic.leftLungMaskSegmentID = self.ui.leftLungMaskSelector.currentSegmentID()
+
+        thresholds = {}
+        thresholds['thresholdBullaLower'] = self.ui.BullaRangeWidget.minimumValue
+        thresholds['thresholdBullaVentilated'] = self.ui.BullaRangeWidget.maximumValue
+        thresholds['thresholdVentilatedInfiltrated'] = self.ui.VentilatedRangeWidget.maximumValue
+        thresholds['thresholdInfiltratedCollapsed'] = self.ui.InfiltratedRangeWidget.maximumValue
+        thresholds['thresholdCollapsedVessels'] = self.ui.CollapsedRangeWidget.maximumValue
+        thresholds['thresholdVesselsUpper'] = self.ui.VesselsRangeWidget.maximumValue
+        self.logic.thresholds = thresholds
+
+        self.logic.rightLungMaskedVolume = self.ui.rightLungMaskedVolumeSelector.currentNode()
+        self.logic.leftLungMaskedVolume = self.ui.leftLungMaskedVolumeSelector.currentNode()
+        self.logic.resultsTable = self.ui.outputResultsTableSelector.currentNode()
+        self.logic.volumeRenderingPropertyNode = self.ui.volumeRenderingPropertyNodeSelector.currentNode()
+        self.logic.covidResultsTable = self.ui.outputCovidResultsTableSelector.currentNode()
+
+        self.logic.generateStatistics = self.ui.generateStatisticsCheckBox.checked
+        self.logic.includeCovidEvaluation = self.ui.includeCovidEvaluationCheckBox.checked
+
+        self._parameterNode.EndModify(wasModified)
+
+    def updateVolumeRenderingProperty(self):
+        thresholds = self.logic.thresholds
+        volumeRenderingPropertyNode = self.logic.volumeRenderingPropertyNode
+        if volumeRenderingPropertyNode:
+            scalarOpacity = vtk.vtkPiecewiseFunction()
+            colorTransferFunction = vtk.vtkColorTransferFunction()
+            scalarOpacity.AddPoint(-3000.0, 0.0)
+            colorTransferFunction.AddRGBPoint(-3000.0, 0.0, 0.0, 0.0)
+            first = True
+            for segmentProperty in self.logic.segmentProperties:
+                opacity = self.opacitySliders[segmentProperty["name"]].value * 0.01
+                lowerThresholdName, upperThresholdName = segmentProperty["thresholds"]
+                lowerThreshold = thresholds[lowerThresholdName]
+                upperThreshold = thresholds[upperThresholdName]-0.1
+                if first:
+                  scalarOpacity.AddPoint(lowerThreshold-0.1, 0.0)
+                  first = False
+                scalarOpacity.AddPoint(lowerThreshold, opacity)
+                scalarOpacity.AddPoint(upperThreshold, opacity)
+                color = segmentProperty["color"]
+                colorTransferFunction.AddRGBPoint(lowerThreshold, *color)
+                colorTransferFunction.AddRGBPoint(upperThreshold, *color)
+            scalarOpacity.AddPoint(upperThreshold+0.1, 0.0)
+            scalarOpacity.AddPoint(5000, 0.0)
+            volumeProperty = volumeRenderingPropertyNode.GetVolumeProperty()
+            volumeProperty.GetScalarOpacity().DeepCopy(scalarOpacity)
+            volumeProperty.GetRGBTransferFunction().DeepCopy(colorTransferFunction)
 
 
-    if self._parameterNode is None or self._updatingGUIFromParameterNode:
-      return
+    def onInputSegmentationSelected(self, segmentationNode):
+        if segmentationNode == self.logic.inputSegmentation:
+            # no change
+            return
 
-    wasModified = self._parameterNode.StartModify()  # Modify all properties in a single batch
+        wasBlockedRight = self.ui.rightLungMaskSelector.blockSignals(True)
+        wasBlockedLeft = self.ui.leftLungMaskSelector.blockSignals(True)
 
-    self._parameterNode.SetNodeReferenceID("InputVolume", self.ui.inputVolumeSelector.currentNodeID)
-    #slicer.util.infoDisplay(self.ui.rightLungMaskSelector.currentNodeID)
-    if self.ui.rightLungMaskSelector.currentNodeID():
-        self._parameterNode.SetNodeReferenceID("RightLungMaskNode",str(self.ui.rightLungMaskSelector.currentNodeID()))
-    if self.ui.leftLungMaskSelector.currentNodeID():
-        self._parameterNode.SetNodeReferenceID("LeftLungMaskNode", str(self.ui.leftLungMaskSelector.currentNodeID()))
+        self.ui.rightLungMaskSelector.setCurrentNode(segmentationNode)
+        self.ui.leftLungMaskSelector.setCurrentNode(segmentationNode)
+        self.ui.rightLungMaskSelector.setCurrentSegmentID(self.findSegmentID(segmentationNode, "right"))
+        self.ui.leftLungMaskSelector.setCurrentSegmentID(self.findSegmentID(segmentationNode, "left"))
 
-    #slicer.util.infoDisplay(self.ui.rightLungMaskSelector.currentNode().GetName())
-    #slicer.util.infoDisplay(self.ui.rightLungMaskSelector.currentNode().GetSegmentation().GetSegment(self.ui.rightLungMaskSelector.currentSegmentID()).GetName())
-    #slicer.util.infoDisplay(self.ui.rightLungMaskSelector.currentSegmentID())
-    #slicer.util.infoDisplay(self.ui.leftLungMaskSelector.currentNodeID())
-    #slicer.util.infoDisplay(self.ui.leftLungMaskSelector.currentSegmentID())
+        self.ui.rightLungMaskSelector.blockSignals(wasBlockedRight)
+        self.ui.leftLungMaskSelector.blockSignals(wasBlockedLeft)
 
-    self._parameterNode.EndModify(wasModified)
+        self.updateParameterNodeFromGUI()
 
-  def onBullaRangeWidgetChanged(self):
-    self.ui.VentilatedRangeWidget.minimumValue = self.ui.BullaRangeWidget.maximumValue 
-    if self.ui.BullaRangeWidget.maximumValue > self.ui.VentilatedRangeWidget.minimumValue: 
-        self.ui.BullaRangeWidget.maximumValue = self.ui.VentilatedRangeWidget.minimumValue  
+    def adjustSliders(self, lowerSlider, slider, upperSlider):
+        wasBlocked = slider.blockSignals(True)
+        if lowerSlider:
+            wasBlockedLower = lowerSlider.blockSignals(True)
+            if slider.minimumValue < lowerSlider.minimumValue:
+                slider.minimumValue = lowerSlider.minimumValue
+            lowerSlider.maximumValue = slider.minimumValue
+            lowerSlider.blockSignals(wasBlockedLower)
+        if upperSlider:
+            wasBlockedUpper = upperSlider.blockSignals(True)
+            if slider.maximumValue > upperSlider.maximumValue:
+                slider.maximumValue = upperSlider.maximumValue
+            upperSlider.minimumValue = slider.maximumValue
+            upperSlider.blockSignals(wasBlockedUpper)
+        slider.blockSignals(wasBlocked)
+        self.updateParameterNodeFromGUI()
 
-  def onVentilatedRangeWidgetChanged(self):
-    self.ui.BullaRangeWidget.maximumValue = self.ui.VentilatedRangeWidget.minimumValue 
-    if self.ui.VentilatedRangeWidget.maximumValue < self.ui.InfiltratedRangeWidget.minimumValue: 
-        self.ui.InfiltratedRangeWidget.minimumValue = self.ui.VentilatedRangeWidget.maximumValue  
-    if self.ui.VentilatedRangeWidget.maximumValue > self.ui.InfiltratedRangeWidget.minimumValue: 
-        self.ui.InfiltratedRangeWidget.minimumValue = self.ui.VentilatedRangeWidget.maximumValue  
-    if self.ui.VentilatedRangeWidget.maximumValue > self.ui.InfiltratedRangeWidget.maximumValue: 
-        self.ui.VentilatedRangeWidget.maximumValue = self.ui.InfiltratedRangeWidget.maximumValue  
+    def onBullaRangeWidgetChanged(self):
+      self.adjustSliders(None, self.ui.BullaRangeWidget, self.ui.VentilatedRangeWidget)
 
-  def onInfiltratedRangeWidgetChanged(self):
-    self.ui.VentilatedRangeWidget.maximumValue = self.ui.InfiltratedRangeWidget.minimumValue 
-    if self.ui.InfiltratedRangeWidget.maximumValue > self.ui.CollapsedRangeWidget.minimumValue: 
-        self.ui.CollapsedRangeWidget.minimumValue = self.ui.InfiltratedRangeWidget.maximumValue  
-    if self.ui.InfiltratedRangeWidget.minimumValue < self.ui.VentilatedRangeWidget.minimumValue: 
-        self.ui.InfiltratedRangeWidget.minimumValue = self.ui.VentilatedRangeWidget.minimumValue  
-    self.ui.CollapsedRangeWidget.minimumValue = self.ui.InfiltratedRangeWidget.maximumValue 
+    def onVentilatedRangeWidgetChanged(self):
+      self.adjustSliders(self.ui.BullaRangeWidget, self.ui.VentilatedRangeWidget, self.ui.InfiltratedRangeWidget)
 
-  def onCollapsedRangeWidgetChanged(self):
-    self.ui.InfiltratedRangeWidget.maximumValue = self.ui.CollapsedRangeWidget.minimumValue 
-    if self.ui.CollapsedRangeWidget.maximumValue > self.ui.VesselsRangeWidget.minimumValue: 
-        self.ui.VesselsRangeWidget.minimumValue = self.ui.CollapsedRangeWidget.maximumValue  
-    if self.ui.CollapsedRangeWidget.minimumValue < self.ui.InfiltratedRangeWidget.minimumValue: 
-        self.ui.CollapsedRangeWidget.minimumValue = self.ui.InfiltratedRangeWidget.minimumValue  
-    self.ui.VesselsRangeWidget.minimumValue = self.ui.CollapsedRangeWidget.maximumValue 
+    def onInfiltratedRangeWidgetChanged(self):
+      self.adjustSliders(self.ui.VentilatedRangeWidget, self.ui.InfiltratedRangeWidget, self.ui.CollapsedRangeWidget)
 
-  def onVesselsRangeWidgetChanged(self):
-    self.ui.CollapsedRangeWidget.maximumValue = self.ui.VesselsRangeWidget.minimumValue 
-    if self.ui.VesselsRangeWidget.minimumValue < self.ui.CollapsedRangeWidget.minimumValue: 
-        self.ui.VesselsRangeWidget.minimumValue = self.ui.CollapsedRangeWidget.minimumValue  
+    def onCollapsedRangeWidgetChanged(self):
+      self.adjustSliders(self.ui.InfiltratedRangeWidget, self.ui.CollapsedRangeWidget, self.ui.VesselsRangeWidget)
 
-  def initThresholds(self):
-    #slicer.util.infoDisplay("Test")
-    logging.info('Restoring defaults')
-    self.ui.BullaRangeWidget.minimumValue = -1000.0
-    self.ui.BullaRangeWidget.maximumValue = -950.
-    self.ui.VentilatedRangeWidget.minimumValue = -950.0
-    self.ui.VentilatedRangeWidget.maximumValue = -750.
-    self.ui.InfiltratedRangeWidget.minimumValue = -750.0
-    self.ui.InfiltratedRangeWidget.maximumValue = -400.
-    self.ui.CollapsedRangeWidget.minimumValue = -400.0
-    self.ui.CollapsedRangeWidget.maximumValue = 0.0
-    self.ui.VesselsRangeWidget.minimumValue = 0.0
-    self.ui.VesselsRangeWidget.maximumValue = 2999.
+    def onVesselsRangeWidgetChanged(self):
+      self.adjustSliders(self.ui.CollapsedRangeWidget, self.ui.VesselsRangeWidget, None)
 
+    def onSaveThresholdsButton(self):
+        logging.info('Saving custom thresholds')
+        self.logic.saveCustomThresholds()
 
-  def onSaveThresholdsButton(self):
-    #slicer.util.infoDisplay("Test")
-    logging.info('Storing defaults')
-    import configparser
-    config = configparser.ConfigParser()
-    #logging.info('Found:' + ctn.GetName())
-    #print(config['DEFAULT']['path'])     # -> "/path/name/"
-    config['DEFAULT']['BullaMinimum'] =  str(self.ui.BullaRangeWidget.minimumValue)    # update
-    config['DEFAULT']['BullaMaximum'] =  str(self.ui.BullaRangeWidget.maximumValue)    # update
-    config['DEFAULT']['VentilatedMinimum'] =  str(self.ui.VentilatedRangeWidget.minimumValue)    # update
-    config['DEFAULT']['VentilatedMaximum'] =  str(self.ui.VentilatedRangeWidget.maximumValue)    # update
-    config['DEFAULT']['InfiltratedMinimum'] =  str(self.ui.InfiltratedRangeWidget.minimumValue)    # update
-    config['DEFAULT']['InfiltratedMaximum'] =  str(self.ui.InfiltratedRangeWidget.maximumValue)    # update
-    config['DEFAULT']['CollapsedMinimum'] =  str(self.ui.CollapsedRangeWidget.minimumValue)    # update
-    config['DEFAULT']['CollapsedMaximum'] =  str(self.ui.CollapsedRangeWidget.maximumValue)    # update
-    config['DEFAULT']['VesselsMinimum'] =  str(self.ui.VesselsRangeWidget.minimumValue)    # update
-    config['DEFAULT']['VesselsMaximum'] =  str(self.ui.VesselsRangeWidget.maximumValue)    # update
-    config['DEFAULT']['default_message'] = 'Thank you for using CTLungAnalyzer!'   # create
-    with open('CTLungAnalyzer.ini', 'w') as configfile:    # save
-        config.write(configfile)
+    def onLoadThresholdsButton(self):
+        logging.info('Loading custom thresholds')
+        self.logic.loadCustomThresholds()
 
-  def onLoadThresholdsButton(self):
-    #slicer.util.infoDisplay("Test")
-    logging.info('Loading defaults')
-    self.initThresholds()
-    import configparser
-    config = configparser.ConfigParser()
-    config.read('CTLungAnalyzer.ini')
-    #logging.info('Found:' + ctn.GetName())
-    #print(config['DEFAULT']['path'])     # -> "/path/name/"
-    self.ui.BullaRangeWidget.minimumValue = float(config['DEFAULT']['BullaMinimum'])
-    self.ui.BullaRangeWidget.maximumValue = float(config['DEFAULT']['BullaMaximum'])
-    self.ui.VentilatedRangeWidget.minimumValue = float(config['DEFAULT']['VentilatedMinimum'])
-    self.ui.VentilatedRangeWidget.maximumValue = float(config['DEFAULT']['VentilatedMaximum'])
-    self.ui.InfiltratedRangeWidget.minimumValue = float(config['DEFAULT']['InfiltratedMinimum'])
-    self.ui.InfiltratedRangeWidget.maximumValue = float(config['DEFAULT']['InfiltratedMaximum'])
-    self.ui.CollapsedRangeWidget.minimumValue = float(config['DEFAULT']['CollapsedMinimum'])
-    self.ui.CollapsedRangeWidget.maximumValue = float(config['DEFAULT']['CollapsedMaximum'])
-    self.ui.VesselsRangeWidget.minimumValue = float(config['DEFAULT']['VesselsMinimum'])
-    self.ui.VesselsRangeWidget.maximumValue = float(config['DEFAULT']['VesselsMaximum'])
-    
-  def onRestoreDefaultsButton(self):
-    #slicer.util.infoDisplay("Test")
-    logging.info('Restoring defaults')
-    self.initThresholds()
+    def onRestoreDefaultsButton(self):
+        logging.info('Restoring default thresholds')
+        self.logic.setThresholds(self._parameterNode, self.logic.defaultThresholds)
 
+    def onDownloadCovidData(self):
+        if not slicer.util.confirmYesNoDisplay("This will clear all data in the scene. Do you want to continue?", windowTitle=None, parent=None):
+            return
 
-  def ondwnlCOVIDDataButton(self):
-    #slicer.util.infoDisplay("Test")
-    if slicer.util.confirmYesNoDisplay("This will clear all data in your current storage node. Are you sure ?", windowTitle=None, parent=None):
-        logging.info('Clearing the MRLM node')
+        logging.info('Clearing the scene')
         slicer.mrmlScene.Clear()
         import SampleData
         logging.info('Registering the sample data')
@@ -399,56 +471,80 @@ class CTLungAnalyzerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         threeDView = threeDWidget.threeDView()
         threeDView.resetFocalPoint()
         logging.info('Normal end of loading procedure.')
-    else: 
-        logging.info('Aborted.')
-    
 
+    def onApplyButton(self):
+        """
+        Run processing when user clicks "Apply" button.
+        """
+        try:
 
+            # Compute output
+            logging.info('Apply')
+            self.logic.process()
 
-  def onSegmentsOnOffButton(self):
-    if segmentationDisplayNode.GetVisibility2D(): 
-        logging.info('Segments visibility off')
-        segmentationDisplayNode.Visibility2DOff()
-    else : 
-        logging.info('Segments visibility on')
-        segmentationDisplayNode.Visibility2DOn()
-        
+            self.onShowResultsTable()
 
+            # ensure user sees the new segments
+            segmentationDisplayNode = self._parameterNode.GetNodeReference("InputSegmentation").GetDisplayNode()
+            segmentationDisplayNode.Visibility2DOn()
+            # hide input segments to make results better visible
+            segmentationDisplayNode.SetSegmentVisibility(self.logic.rightLungMaskSegmentID, False)
+            segmentationDisplayNode.SetSegmentVisibility(self.logic.leftLungMaskSegmentID, False)
 
-  def onApplyButton(self):
-    """
-    Run processing when user clicks "Apply" button.
-    """
-    try:
+        except Exception as e:
+            slicer.util.errorDisplay("Failed to compute results: "+str(e))
+            import traceback
+            traceback.print_exc()
 
-      # Compute output
-      self.logic.process(self.ui.inputVolumeSelector.currentNode(),
-      self.ui.rightLungMaskSelector.currentNode(),
-      self.ui.leftLungMaskSelector.currentNode(),
-      self.ui.rightLungMaskSelector.currentSegmentID(),
-      self.ui.leftLungMaskSelector.currentSegmentID(),
-      self.ui.BullaRangeWidget.minimumValue,
-      self.ui.BullaRangeWidget.maximumValue,
-      self.ui.VentilatedRangeWidget.minimumValue,
-      self.ui.VentilatedRangeWidget.maximumValue,
-      self.ui.InfiltratedRangeWidget.minimumValue,
-      self.ui.InfiltratedRangeWidget.maximumValue,
-      self.ui.CollapsedRangeWidget.minimumValue,
-      self.ui.CollapsedRangeWidget.maximumValue,
-      self.ui.VesselsRangeWidget.minimumValue,
-      self.ui.VesselsRangeWidget.maximumValue,
-      self.ui.generateStatisticsCheckBox.checked,
-      self.ui.deletePreviousSegmentationsCheckBox.checked,
-      self.ui.includeCovidEvaluationCheckBox.checked,
-      self.ui.show3DCheckBox.checked
-      )
-      #logging.info('Apply button')
+    def onShowResultsTable(self):
+        tableNode = self._parameterNode.GetNodeReference("OutputResultsTable")
+        if tableNode:
+            self.logic.showTable(tableNode)
 
+    def onShowCovidResultsTable(self):
+        tableNode = self._parameterNode.GetNodeReference("OutputCovidResultsTable")
+        if tableNode:
+            self.logic.showTable(tableNode)
 
-    except Exception as e:
-      slicer.util.errorDisplay("Failed to compute results: "+str(e))
-      import traceback
-      traceback.print_exc()
+    def onToggleSegmentsVisibility(self):
+        segmentationDisplayNode = self._parameterNode.GetNodeReference("InputSegmentation").GetDisplayNode()
+        if segmentationDisplayNode.GetVisibility2D():
+            logging.info('Segments visibility off')
+            segmentationDisplayNode.Visibility2DOff()
+        else :
+            logging.info('Segments visibility on')
+            segmentationDisplayNode.Visibility2DOn()
+
+    def onShowSegmentsIn3D(self):
+        segmentationNode = self.logic.inputSegmentation
+        segmentationNode.CreateClosedSurfaceRepresentation()
+
+    def onToggleVolumeRendering(self, side):
+        volumeRenderingPropertyNode = self.logic.volumeRenderingPropertyNode
+        if not volumeRenderingPropertyNode:
+            self.logic.volumeRenderingPropertyNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLVolumePropertyNode", "LungCT")
+            volumeRenderingPropertyNode = self.logic.volumeRenderingPropertyNode
+            self.updateVolumeRenderingProperty()
+
+        volRenLogic = slicer.modules.volumerendering.logic()
+        volumeNode = self.logic.rightLungMaskedVolume if side=="right" else self.logic.leftLungMaskedVolume
+        displayNode = volRenLogic.GetFirstVolumeRenderingDisplayNode(volumeNode)
+        if displayNode:
+          wasVisible = displayNode.GetVisibility()
+        else:
+          displayNode = volRenLogic.CreateDefaultVolumeRenderingNodes(volumeNode)
+          wasVisible = False
+
+        displayNode.SetAndObserveVolumePropertyNodeID(volumeRenderingPropertyNode.GetID())
+        displayNode.SetVisibility(not wasVisible)
+        # Makes the view displayed off-centered if multi-volume rendering is used
+        # if not wasVisible:
+        #     # center 3D view
+        #     layoutManager = slicer.app.layoutManager()
+        #     if layoutManager.threeDViewCount > 0:
+        #         threeDWidget = layoutManager.threeDWidget(0)
+        #         threeDView = threeDWidget.threeDView()
+        #         threeDView.resetFocalPoint()
 
 
 #
@@ -456,399 +552,233 @@ class CTLungAnalyzerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 #
 
 class CTLungAnalyzerLogic(ScriptedLoadableModuleLogic):
-  """This class should implement all the actual
-  computation done by your module.  The interface
-  should be such that other python code can import
-  this class and make use of the functionality without
-  requiring an instance of the Widget.
-  Uses ScriptedLoadableModuleLogic base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
-  """
-
-  def __init__(self):
+    """This class should implement all the actual
+    computation done by your module.  The interface
+    should be such that other python code can import
+    this class and make use of the functionality without
+    requiring an instance of the Widget.
+    Uses ScriptedLoadableModuleLogic base class, available at:
+    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
-    Called when the logic class is instantiated. Can be used for initializing member variables.
-    """
-    logging.info('_init_')
-    ScriptedLoadableModuleLogic.__init__(self)
- 
 
-  def setDefaultParameters(self, parameterNode):
-    """
-    Initialize parameter node with default settings.
-    """
-    logging.info('setDefaultParameters')
-    if not parameterNode.GetParameter("Threshold"):
-      parameterNode.SetParameter("Threshold", "100.0")
-    if not parameterNode.GetParameter("Invert"):
-      parameterNode.SetParameter("Invert", "false")
+    def __init__(self):
+        """
+        Called when the logic class is instantiated. Can be used for initializing member variables.
+        """
+        ScriptedLoadableModuleLogic.__init__(self)
+        self.defaultThresholds = {
+            'thresholdBullaLower': -1000.,
+            'thresholdBullaVentilated': -950.,
+            'thresholdVentilatedInfiltrated': -750.,
+            'thresholdInfiltratedCollapsed': -400.,
+            'thresholdCollapsedVessels': 0.,
+            'thresholdVesselsUpper': 3000.,
+            }
 
-  def process(self, inputVolume, rightLungMaskNode, leftLungMaskNode, rightLungMaskID, leftLungMaskID, bullMin,bullMax,ventMin,ventMax,infMin,infMax,collMin,collMax, vessMin, vessMax, genstat_cb, delprev_cb, inccov_cb, show3D_cb):
-    """
-    Run the processing algorithm.
-    Can be used without GUI widget.
-    :param inputVolume: volume to be thresholded
-    """
-    logging.info('Processing started.')
+        self.segmentProperties = [
+            {"name": "Emphysema", "color": [0.0,0.0,0.0], "thresholds": ['thresholdBullaLower', 'thresholdBullaVentilated']},
+            {"name": "Ventilated", "color": [0.0,0.5,1.0], "thresholds": ['thresholdBullaVentilated', 'thresholdVentilatedInfiltrated']},
+            {"name": "Infiltration", "color": [1.0,0.5,0.0], "thresholds": ['thresholdVentilatedInfiltrated', 'thresholdInfiltratedCollapsed']},
+            {"name": "Collapsed", "color": [1.0,0.0,1.0], "thresholds": ['thresholdInfiltratedCollapsed', 'thresholdCollapsedVessels']},
+            {"name": "Vessels", "color": [1.0,0.0,0.0], "thresholds": ['thresholdCollapsedVessels', 'thresholdVesselsUpper']},
+            ]
 
-    if not inputVolume:
-      raise ValueError("Input volume is invalid")
-    logging.info('Input present.')
+    def setThresholds(self, parameterNode, thresholds, overwrite=True):
+        wasModified = parameterNode.StartModify()
+        for parameterName in thresholds:
+            if parameterNode.GetParameter(parameterName) and not overwrite:
+                continue
+            parameterNode.SetParameter(parameterName, str(thresholds[parameterName]))
+        parameterNode.EndModify(wasModified)
 
-    import time
-    startTime = time.time()
+    def saveCustomThresholds(self):
+        parameterNode = self.getParameterNode()
+        thresholds = {}
+        for parameterName in self.defaultThresholds:
+            thresholds[parameterName] = float(parameterNode.GetParameter(parameterName))
+        slicer.app.settings().setValue("CTLungAnalyzer/CustomThresholds",str(thresholds))
+
+    def loadCustomThresholds(self):
+        import ast
+        thresholds = ast.literal_eval(slicer.app.settings().value("CTLungAnalyzer/CustomThresholds", "{}"))
+        self.setThresholds(self.getParameterNode(), thresholds)
+
+    def setDefaultParameters(self, parameterNode):
+        """
+        Initialize parameter node with default settings.
+        """
+        logging.info('setDefaultParameters')
+        self.setThresholds(parameterNode, self.defaultThresholds, overwrite=False)
+        if not parameterNode.GetParameter("ComputeImageIntensityStatistics"):
+            parameterNode.SetParameter("ComputeImageIntensityStatistics", "true")
+        if not parameterNode.GetParameter("ComputeCovid"):
+            parameterNode.SetParameter("ComputeCovid", "false")
+
+    def createMaskedVolume(self, side, segmentID):
+        # Get output volume
+        volumesLogic = slicer.modules.volumes.logic()
+        if side == "right":
+            if not self.rightLungMaskedVolume:
+                self.rightLungMaskedVolume = volumesLogic.CloneVolumeGeneric(self.inputVolume.GetScene(), self.inputVolume,
+                    "Right lung masked volume", False)
+            outputVolume = self.rightLungMaskedVolume
+        else:
+            if not self.leftLungMaskedVolume:
+                self.leftLungMaskedVolume = volumesLogic.CloneVolumeGeneric(self.inputVolume.GetScene(), self.inputVolume,
+                    "Left lung masked volume", False)
+            outputVolume = self.leftLungMaskedVolume
+
+        # Mask segment
+        try:
+            import SegmentEditorMaskVolumeLib
+        except ImportError:
+            raise ValueError("Please install 'SegmentEditorExtraEffects' extension using Extension Manager.")
+
+        fillValue = self.inputVolume.GetImageData().GetScalarRange()[0]  # volume's minimum value
+        SegmentEditorMaskVolumeLib.SegmentEditorEffect.maskVolumeWithSegment(self.inputSegmentation, segmentID,
+            "FILL_OUTSIDE", [fillValue], self.inputVolume, outputVolume)
+
+    def createThresholdedSegments(self, side, maskSegmentId):
+        # Create temporary segment editor to get access to effects
+        logging.info('Create temporary segment editor ....')
+        segmentEditorWidget = slicer.qMRMLSegmentEditorWidget()
+        segmentEditorWidget.setMRMLScene(slicer.mrmlScene)
+        segmentEditorNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentEditorNode")
+        segmentEditorWidget.setMRMLSegmentEditorNode(segmentEditorNode)
+        segmentEditorWidget.setSegmentationNode(self.inputSegmentation)
+        segmentEditorWidget.setMasterVolumeNode(self.inputVolume)
+
+        segmentationDisplayNode = self.inputSegmentation.GetDisplayNode()
+        segmentation = self.inputSegmentation.GetSegmentation()
+
+        thresholds = self.thresholds
+        # Create segments by thresholding
+        for segmentProperty in self.segmentProperties:
+            segmentName = f"{segmentProperty['name']} {side}"
+            segmentId = segmentation.GetSegmentIdBySegmentName(segmentName)
+            if not segmentId:
+                # Create segment
+                logging.info('Creating segment '+segmentName)
+                segmentId = self.inputSegmentation.GetSegmentation().AddEmptySegment(segmentName)
+                # Set color
+                segmentId = segmentation.GetSegmentIdBySegmentName(segmentName)
+                segmentationDisplayNode.SetSegmentOpacity3D(segmentId, 0.2)
+                #segmentationDisplayNode.SetSegmentOpacity(segmentId,1.)
+                segmentationDisplayNode.SetSegmentOpacity2DFill(segmentId, 0.5)
+                segmentationDisplayNode.SetSegmentOpacity2DOutline(segmentId, 0.2)
+                r, g, b = segmentProperty['color']
+                segmentation.GetSegment(segmentId).SetColor(r,g,b)  # color should be set in segmentation node
+            else:
+                logging.info('Updating segment '+segmentName)
+                slicer.modules.segmentations.logic().ClearSegment(self.inputSegmentation, segmentId)
+
+            # Fill by thresholding
+            #logging.info('Thresholding '+segmentName)
+            logging.info('Thresholding using mask segment id '+maskSegmentId)
+            segmentEditorNode.SetMaskSegmentID(maskSegmentId)
+            segmentEditorNode.SetOverwriteMode(slicer.vtkMRMLSegmentEditorNode.OverwriteNone)
+            segmentEditorNode.SetMaskMode(slicer.vtkMRMLSegmentationNode.EditAllowedInsideSingleSegment)
+            segmentEditorNode.SetSelectedSegmentID(segmentId)
+            segmentEditorWidget.setActiveEffectByName("Threshold")
+            effect = segmentEditorWidget.activeEffect()
+            lowerThresholdName, upperThresholdName = segmentProperty["thresholds"]
+            effect.setParameter("MinimumThreshold", str(thresholds[lowerThresholdName]))
+            effect.setParameter("MaximumThreshold", str(thresholds[upperThresholdName]))
+            effect.self().onApply()
+
+        # Delete temporary segment editor
+        segmentEditorWidget = None
+        slicer.mrmlScene.RemoveNode(segmentEditorNode)
+
+    def createResultsTable(self):
+        logging.info('Create results table')
+
+        if not self.resultsTable:
+            self.resultsTable = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLTableNode', 'Lung CT analysis results')
+        else:
+            self.resultsTable.RemoveAllColumns()
+
+        import SegmentStatistics
+        segStatLogic = SegmentStatistics.SegmentStatisticsLogic()
+        segStatLogic.getParameterNode().SetParameter("Segmentation", self.inputSegmentation.GetID())
+        segStatLogic.getParameterNode().SetParameter("ScalarVolume", self.inputVolume.GetID())
+        segStatLogic.getParameterNode().SetParameter("LabelmapSegmentStatisticsPlugin.enabled", "True" if self.generateStatistics else "False")
+        segStatLogic.getParameterNode().SetParameter("ScalarVolumeSegmentStatisticsPlugin.voxel_count.enabled", "False")
+        segStatLogic.getParameterNode().SetParameter("ScalarVolumeSegmentStatisticsPlugin.volume_mm3.enabled", "False")
+        segStatLogic.computeStatistics()
+        segStatLogic.exportToTable(self.resultsTable)
+
+        minThrCol = vtk.vtkFloatArray()
+        minThrCol.SetName("MinThr")
+        self.resultsTable.AddColumn(minThrCol)
+        maxThrCol = vtk.vtkFloatArray()
+        maxThrCol.SetName("MaxThr")
+        self.resultsTable.AddColumn(maxThrCol)
+
+        parameterNode = self.getParameterNode()
+
+        segmentNameColumn = self.resultsTable.GetTable().GetColumnByName("Segment")
+        for side in ['left', 'right']:
+            for segmentProperty in self.segmentProperties:
+                segmentName = f"{segmentProperty['name']} {side}"
+                rowIndex = segmentNameColumn.LookupValue(segmentName)
+                lowerThresholdName, upperThresholdName = segmentProperty["thresholds"]
+                minThrCol.SetValue(rowIndex, float(parameterNode.GetParameter(lowerThresholdName)))
+                maxThrCol.SetValue(rowIndex, float(parameterNode.GetParameter(upperThresholdName)))
+        self.resultsTable.GetTable().Modified()
+
+    def createCovidResultsTable(self):
+
+        if not self.covidResultsTable:
+            self.covidResultsTable = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLTableNode', 'Lung CT COVID-19 analysis results')
+        else:
+            self.covidResultsTable.RemoveAllColumns()
+
+        resultsTableNode = self.covidResultsTable
+        # Add a new column
+        # Compute segment volumes
+
+        _bulRightLung = round(float(resultsTableNode.GetCellText(0,3)))
+        _venRightLung = round(float(resultsTableNode.GetCellText(1,3)))
+        _infRightLung = round(float(resultsTableNode.GetCellText(2,3)))
+        _colRightLung = round(float(resultsTableNode.GetCellText(3,3)))
+        _vesRightLung = round(float(resultsTableNode.GetCellText(4,3)))
+        _bulLeftLung = round(float(resultsTableNode.GetCellText(5,3)))
+        _venLeftLung = round(float(resultsTableNode.GetCellText(6,3)))
+        _infLeftLung = round(float(resultsTableNode.GetCellText(7,3)))
+        _colLeftLung = round(float(resultsTableNode.GetCellText(8,3)))
+        _vesLeftLung = round(float(resultsTableNode.GetCellText(9,3)))
+
+        _rightLungVolume = _bulRightLung + _venRightLung + _infRightLung + _colRightLung - _vesRightLung
+        _leftLungVolume = _bulLeftLung + _venLeftLung + _infLeftLung + _colLeftLung - _vesLeftLung
+        _totalLungVolume = _rightLungVolume + _leftLungVolume
+
+        _functionalRightVolume = _venRightLung
+        _functionalLeftVolume = _venLeftLung
+        _functionalTotalVolume = _venRightLung + _venLeftLung
+
+        _affectedRightVolume = _infRightLung + _colRightLung + _bulRightLung
+        _affectedLeftVolume = _infLeftLung + _colLeftLung + _bulLeftLung
+        _affectedTotalVolume = _infRightLung + _colRightLung + _infLeftLung + _colLeftLung + _bulRightLung+ _bulLeftLung
+
+        _rightLungVolumePerc = round(_rightLungVolume * 100. / _totalLungVolume)
+        _leftLungVolumePerc = round(_leftLungVolume * 100. / _totalLungVolume)
+        _totalLungVolumePerc = 100.
+
+        _functionalRightVolumePerc = round(_functionalRightVolume * 100. / _rightLungVolume)
+        _functionalLeftVolumePerc = round(_functionalLeftVolume * 100. / _leftLungVolume)
+        _functionalTotalVolumePerc = round(_functionalTotalVolume * 100. / _totalLungVolume)
+
+        _affectedRightVolumePerc = round(_affectedRightVolume * 100. / _rightLungVolume)
+        _affectedLeftVolumePerc = round(_affectedLeftVolume * 100. / _leftLungVolume)
+        _affectedTotalVolumePerc = round(_affectedTotalVolume * 100. / _totalLungVolume)
 
 
-    # Compute 
-    masterVolumeNode = inputVolume
+        _CovidQ = round(_affectedTotalVolume / _totalLungVolume,2)
 
-    if delprev_cb: 
-        # Delete previous clutter segments if present (and requested) 
-        logging.info('Delete clutter segments ....')
-        allSegmentNodes = slicer.util.getNodes('vtkMRMLSegmentationNode*').values()
-        for ctn in allSegmentNodes:
-          #logging.info('Name:>' + ctn.GetName()+'<')
-          teststr = ctn.GetName()
-          if 'Segmentation_' in teststr:
-            #logging.info('Found:' + ctn.GetName())
-            if not (teststr == rightLungMaskNode.GetName() or teststr == leftLungMaskNode.GetName()):
-                #do not delete the lung mask segmentation if its name is in the format 'Segmentation_'
-                slicer.mrmlScene.RemoveNode(ctn)
-            #break        
+        covidResultsTableNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLTableNode')
+        resTableNode = covidResultsTableNode
 
-    #slicer.mrmlScene.RemoveNode(slicer.util.getNode('Right lung masked volume'))
-    logging.info('Delete old lungmask volumes ....')
-    slicer.mrmlScene.RemoveNode(slicer.mrmlScene.GetFirstNodeByName('Right lung masked volume'))
-    slicer.mrmlScene.RemoveNode(slicer.mrmlScene.GetFirstNodeByName('Left lung masked volume'))
-
-
-    #slicer.util.infoDisplay(rightLungMaskNode.GetSegmentation().GetSegment(rightLungMaskID).GetName())
-    
-    logging.info('Check right lung mask present ....')
-    if rightLungMaskNode.GetSegmentation().GetSegment(rightLungMaskID).GetName().upper() != "RIGHT LUNG MASK":
-        raise ValueError("You did not pick a segmentation with the name 'Right lung ´mask' in the mandatory drop down field. Procedure aborted.")    
-
-    logging.info('Check left lung mask present ....')
-    if rightLungMaskNode.GetSegmentation().GetSegment(leftLungMaskID).GetName().upper() != "LEFT LUNG MASK":
-        raise ValueError("You did not pick a segmentation with the name 'Left lung mask' in the mandatory drop down field. Procedure aborted.")    
-   
-    # Create segmentation
-    #try: 
-    #    maskSegmentationNode = slicer.util.getNode('Segmentation')
-    #except Exception as e:
-    #  slicer.util.errorDisplay("Failed to compute results: "+str(e))
-    #  slicer.util.confirmOkCancelDisplay("Help on this error: Unable to find mask segmentation node. This module needs a 3D slicer node 'Segmentation' with two segments: 'Right lung mask' (1st segment) and 'Left lung mask' (2nd segment). Please prepare this node now and run the module again.")
-    #  import traceback
-    #  traceback.print_exc()
-    #  raise ValueError("Procedure is cancelled.")    
-    
-    logging.info('Add segmentation node ....')
-    segmentationNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
-        
-    #segmentationNode = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLSegmentationNode")
-    #segmentationNode = slicer.util.getNode('Segmentation')
-    
-    logging.info('Create default display ....')
-    segmentationNode.CreateDefaultDisplayNodes() # only needed for display
-    segmentationNode.SetReferenceImageGeometryParameterFromVolumeNode(masterVolumeNode)
-
-    # Create temporary segment editor to get access to effects
-    logging.info('Create temporary segment editor ....')
-    segmentEditorWidget = slicer.qMRMLSegmentEditorWidget()
-    segmentEditorWidget.setMRMLScene(slicer.mrmlScene)
-    segmentEditorNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentEditorNode")
-    segmentEditorWidget.setMRMLSegmentEditorNode(segmentEditorNode)
-    #segmentEditorNode.SetMaskSegmentID(segmentationNode.GetSegmentation().GetNthSegmentID(0))
-    #segmentEditorNode.SetOverwriteMode(slicer.vtkMRMLSegmentEditorNode.OverwriteAllSegments)
-    #segmentEditorNode.SetMaskMode(slicer.vtkMRMLSegmentEditorNode.PaintAllowedInsideSingleSegment)
-    if not segmentEditorWidget.effectByName("Mask volume"):
-        slicer.util.errorDisplay("Please install 'SegmentEditorExtraEffects' extension using Extension Manager.")
-
-    logging.info('Get Display node ....')
-    global segmentationDisplayNode
-    segmentationDisplayNode=segmentationNode.GetDisplayNode()
-    logging.info('Get segmentation ....')
-    segmentation=segmentationNode.GetSegmentation()
-
-    # Create a lung volume
-    # This has to be done because of a bug within slicer. 
-    # If you don't do this, the segmenteditorWidget will present an exception like error message
-    # but only on the first try  
-    
-    logging.info('Create false lung volume ....')
-    # Create right lung volume
-    segmentEditorWidget.setMasterVolumeNode(masterVolumeNode)
-    segmentEditorWidget.setSegmentationNode(rightLungMaskNode)
-    segmentEditorWidget.setCurrentSegmentID(rightLungMaskID)
-    # Set up masking parameters
-    segmentEditorWidget.setActiveEffectByName("Mask volume")
-    effect = segmentEditorWidget.activeEffect()
-    segmentEditorNode.SetMaskSegmentID(rightLungMaskID)
-    segmentEditorNode.SetMasterVolumeIntensityMask(False)
-    #segmentEditorNode.SetMasterVolumeIntensityMask(True)
-    #segmentEditorNode.SetMasterVolumeIntensityMaskRange(6900, 7000)
-    effect.setParameter("Operation", "FILL_OUTSIDE")
-    effect.setParameter("FillValue", str(inputVolume.GetImageData().GetScalarRange()[0]))
-    #effect.setParameter("FillValue", "3000")
-    falseMaskedVolume = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", "False lung masked volume")
-    effect.self().outputVolumeSelector.setCurrentNode(falseMaskedVolume)
-    effect.self().onApply()
-
-    logging.info('Create right lung volume ....')
-    # Create right lung volume
-    segmentEditorWidget.setMasterVolumeNode(masterVolumeNode)
-    segmentEditorWidget.setSegmentationNode(rightLungMaskNode)
-    segmentEditorWidget.setCurrentSegmentID(rightLungMaskID)
-    # Set up masking parameters
-    segmentEditorWidget.setActiveEffectByName("Mask volume")
-    effect = segmentEditorWidget.activeEffect()
-    segmentEditorNode.SetMaskSegmentID(rightLungMaskID)
-    segmentEditorNode.SetMasterVolumeIntensityMask(False)
-    #segmentEditorNode.SetMasterVolumeIntensityMask(True)
-    #segmentEditorNode.SetMasterVolumeIntensityMaskRange(6900, 7000)
-    effect.setParameter("Operation", "FILL_OUTSIDE")
-    effect.setParameter("FillValue", str(inputVolume.GetImageData().GetScalarRange()[0]))
-    #effect.setParameter("FillValue", "3000")
-    rightMaskedVolume = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", "Right lung masked volume")
-    effect.self().outputVolumeSelector.setCurrentNode(rightMaskedVolume)
-    effect.self().onApply()
-
-    logging.info('Create left lung volume ....')
-    # Create left lung volume
-    segmentEditorWidget.setMasterVolumeNode(masterVolumeNode)
-    segmentEditorWidget.setSegmentationNode(leftLungMaskNode)
-    segmentEditorWidget.setCurrentSegmentID(leftLungMaskID)
-    # Set up masking parameters
-    segmentEditorWidget.setActiveEffectByName("Mask volume")
-    effect = segmentEditorWidget.activeEffect()
-    segmentEditorNode.SetMaskSegmentID(leftLungMaskID)
-    segmentEditorNode.SetMasterVolumeIntensityMask(False)
-    #segmentEditorNode.SetMasterVolumeIntensityMask(True)
-    #segmentEditorNode.SetMasterVolumeIntensityMaskRange(6900, 7000)
-    effect.setParameter("Operation", "FILL_OUTSIDE")
-    effect.setParameter("FillValue", str(inputVolume.GetImageData().GetScalarRange()[0]))
-    #effect.setParameter("FillValue", "3000")
-    leftMaskedVolume = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", "Left lung masked volume")
-    effect.self().outputVolumeSelector.setCurrentNode(leftMaskedVolume)
-    effect.self().onApply()
-    
-    logging.info('Create right lung segments ....')
-    segmentEditorWidget.setMasterVolumeNode(rightMaskedVolume)
-    segmentationNode.SetReferenceImageGeometryParameterFromVolumeNode(rightMaskedVolume)
-    segmentEditorWidget.setSegmentationNode(segmentationNode)
-
-    # Create segments by thresholding
-    segmentsFromHounsfieldUnits = [
-        ["Emphysema right", 0.0,0.0,0.0],
-        ["Ventilated right", 0.0,0.5,1.0],
-        ["Infiltration right", 1.0,0.5,0.0],
-        ["Collapsed right", 1.0,0.0,1.0],
-        ["Vessels right", 1.0,0.0,0.0] ]
-
-    #for segmentName, thresholdMin, thresholdMax, r, g, b in segmentsFromHounsfieldUnits:
-        # Delete previous segments
-        #logging.info('Deleting segment.')
-        #segmentId = segmentation.GetSegmentIdBySegmentName(segmentName)
-        #segmentation.RemoveSegment(segmentId)
-        
-    for segmentName, r, g, b in segmentsFromHounsfieldUnits:
-        # Create segment
-        logging.info('Creating segment.')
-        addedSegmentID = segmentationNode.GetSegmentation().AddEmptySegment(segmentName)
-        segmentEditorNode.SetSelectedSegmentID(addedSegmentID)
-        # Set color
-        #logging.info('Setting segment color.')
-        segmentId = segmentation.GetSegmentIdBySegmentName(segmentName)
-        segmentationDisplayNode.SetSegmentOpacity3D(segmentId,0.2)
-        #segmentationDisplayNode.SetSegmentOpacity(segmentId,1.)
-        segmentationDisplayNode.SetSegmentOpacity2DFill(segmentId,1.5)
-        segmentationDisplayNode.SetSegmentOpacity2DOutline(segmentId,0.2)
-        segmentation.GetSegment(segmentId).SetColor(r,g,b)  # color should be set in segmentation node
-        # Fill by thresholding
-        logging.info('Thresholding.')
-        segmentEditorWidget.setActiveEffectByName("Threshold")
-        effect = segmentEditorWidget.activeEffect()
-        if 'Emphysema' in segmentName:
-            effect.setParameter("MinimumThreshold",str(bullMin))
-            effect.setParameter("MaximumThreshold",str(bullMax))     
-        if 'Ventilated' in segmentName:
-            effect.setParameter("MinimumThreshold",str(ventMin))
-            effect.setParameter("MaximumThreshold",str(ventMax))     
-        if 'Infiltration' in segmentName:
-            effect.setParameter("MinimumThreshold",str(infMin))
-            effect.setParameter("MaximumThreshold",str(infMax))     
-        if 'Collapsed' in segmentName:
-            effect.setParameter("MinimumThreshold",str(collMin))
-            effect.setParameter("MaximumThreshold",str(collMax))            
-        if 'Vessels' in segmentName:
-            effect.setParameter("MinimumThreshold",str(vessMin))
-            effect.setParameter("MaximumThreshold",str(vessMax))            
-        effect.self().onApply()
-    
-    logging.info('Creat left lung  segments ....')
-    segmentEditorWidget.setMasterVolumeNode(leftMaskedVolume)
-    segmentationNode.SetReferenceImageGeometryParameterFromVolumeNode(leftMaskedVolume)
-    segmentEditorWidget.setSegmentationNode(segmentationNode)
-
-    # Create segments by thresholding
-    segmentsFromHounsfieldUnits = [
-        ["Emphysema left", 0.0,0.0,0.0],
-        ["Ventilated left", 0,0.5,1.0],
-        ["Infiltration left", 1.0,0.5,0.0],
-        ["Collapsed left", 1.0,0.0,1.0],
-        ["Vessels", 1.0,0.0,0.0] ]
-
-    #for segmentName, thresholdMin, thresholdMax, r, g, b in segmentsFromHounsfieldUnits:
-        # Delete previous segments
-        #logging.info('Deleting segment.')
-        #segmentId = segmentation.GetSegmentIdBySegmentName(segmentName)
-        #segmentation.RemoveSegment(segmentId)
-        
-    for segmentName, r, g, b in segmentsFromHounsfieldUnits:
-        # Create segment
-        logging.info('Creating segment.')
-        addedSegmentID = segmentationNode.GetSegmentation().AddEmptySegment(segmentName)
-        segmentEditorNode.SetSelectedSegmentID(addedSegmentID)
-        # Set color
-        #logging.info('Setting segment color.')
-        segmentId = segmentation.GetSegmentIdBySegmentName(segmentName)
-        segmentationDisplayNode.SetSegmentOpacity3D(segmentId,0.2)
-        #segmentationDisplayNode.SetSegmentOpacity(segmentId,1.)
-        segmentationDisplayNode.SetSegmentOpacity2DFill(segmentId,1.5)
-        segmentationDisplayNode.SetSegmentOpacity2DOutline(segmentId,0.2)
-        segmentation.GetSegment(segmentId).SetColor(r,g,b)  # color should be set in segmentation node
-        # Fill by thresholding
-        logging.info('Thresholding.')
-        segmentEditorWidget.setActiveEffectByName("Threshold")
-        effect = segmentEditorWidget.activeEffect()
-        if 'Emphysema' in segmentName:
-            effect.setParameter("MinimumThreshold",str(bullMin))
-            effect.setParameter("MaximumThreshold",str(bullMax))     
-        if 'Ventilated' in segmentName:
-            effect.setParameter("MinimumThreshold",str(ventMin))
-            effect.setParameter("MaximumThreshold",str(ventMax))     
-        if 'Infiltration' in segmentName:
-            effect.setParameter("MinimumThreshold",str(infMin))
-            effect.setParameter("MaximumThreshold",str(infMax))     
-        if 'Collapsed' in segmentName:
-            effect.setParameter("MinimumThreshold",str(collMin))
-            effect.setParameter("MaximumThreshold",str(collMax))            
-        if 'Vessels' in segmentName:
-            effect.setParameter("MinimumThreshold",str(vessMin))
-            effect.setParameter("MaximumThreshold",str(vessMax))            
-        effect.self().onApply()
-    
-    
-
-    # Delete temporary segment editor
-    segmentEditorWidget.setMasterVolumeNode(inputVolume)
-    segmentationNode.SetReferenceImageGeometryParameterFromVolumeNode(inputVolume)
-    segmentEditorWidget = None
-    slicer.mrmlScene.RemoveNode(segmentEditorNode)
-
-   # Delete existing model storage nodes so that they will be recreated with default settings
-    if delprev_cb: 
-        existingTableNodes = slicer.util.getNodesByClass('vtkMRMLTableNode')
-        for TableNode in existingTableNodes:
-            slicer.mrmlScene.RemoveNode(TableNode)
-
-    logging.info('Create Tables ....')        
-    # Compute segment volumes
-    resultsTableNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLTableNode')
-    import SegmentStatistics
-    segStatLogic = SegmentStatistics.SegmentStatisticsLogic()
-    segStatLogic.getParameterNode().SetParameter("Segmentation", segmentationNode.GetID())
-    segStatLogic.getParameterNode().SetParameter("ScalarVolume", masterVolumeNode.GetID())
-    
-
-    if genstat_cb: 
-        segStatLogic.getParameterNode().SetParameter("LabelmapSegmentStatisticsPlugin.enabled","True")
-    else:
-        segStatLogic.getParameterNode().SetParameter("LabelmapSegmentStatisticsPlugin.enabled","False")
-    segStatLogic.getParameterNode().SetParameter("ScalarVolumeSegmentStatisticsPlugin.voxel_count.enabled","False")
-    segStatLogic.getParameterNode().SetParameter("ScalarVolumeSegmentStatisticsPlugin.volume_mm3.enabled","False")
-    segStatLogic.computeStatistics()
-    segStatLogic.exportToTable(resultsTableNode)
-
-    minThrCol = vtk.vtkFloatArray()
-    minThrCol.SetName("MinThr")
-    minThrCol.InsertNextValue(bullMin) #right lung
-    minThrCol.InsertNextValue(ventMin)
-    minThrCol.InsertNextValue(infMin)
-    minThrCol.InsertNextValue(collMin)
-    minThrCol.InsertNextValue(vessMin)
-    minThrCol.InsertNextValue(bullMin) #left lung
-    minThrCol.InsertNextValue(ventMin)
-    minThrCol.InsertNextValue(infMin)
-    minThrCol.InsertNextValue(collMin)
-    minThrCol.InsertNextValue(vessMin)
-
-    maxThrCol = vtk.vtkFloatArray()
-    maxThrCol.SetName("MaxThr")
-    maxThrCol.InsertNextValue(bullMax) #right lung
-    maxThrCol.InsertNextValue(ventMax)
-    maxThrCol.InsertNextValue(infMax)
-    maxThrCol.InsertNextValue(collMax)
-    maxThrCol.InsertNextValue(vessMax)
-    maxThrCol.InsertNextValue(bullMax) #left lung
-    maxThrCol.InsertNextValue(ventMax)
-    maxThrCol.InsertNextValue(infMax)
-    maxThrCol.InsertNextValue(collMax)
-    maxThrCol.InsertNextValue(vessMax)
-    
-    column = resultsTableNode.AddColumn(minThrCol)
-    column = resultsTableNode.AddColumn(maxThrCol)
-
-    segStatLogic.showTable(resultsTableNode)
-    
-    # Add a new column
-    # Compute segment volumes
-    
-    _bulRightLung = round(float(resultsTableNode.GetCellText(0,3)))
-    _venRightLung = round(float(resultsTableNode.GetCellText(1,3)))
-    _infRightLung = round(float(resultsTableNode.GetCellText(2,3)))
-    _colRightLung = round(float(resultsTableNode.GetCellText(3,3)))
-    _vesRightLung = round(float(resultsTableNode.GetCellText(4,3)))
-    _bulLeftLung = round(float(resultsTableNode.GetCellText(5,3)))
-    _venLeftLung = round(float(resultsTableNode.GetCellText(6,3)))
-    _infLeftLung = round(float(resultsTableNode.GetCellText(7,3)))
-    _colLeftLung = round(float(resultsTableNode.GetCellText(8,3)))
-    _vesLeftLung = round(float(resultsTableNode.GetCellText(9,3)))
-    
-    _rightLungVolume = _bulRightLung + _venRightLung + _infRightLung + _colRightLung - _vesRightLung
-    _leftLungVolume = _bulLeftLung + _venLeftLung + _infLeftLung + _colLeftLung - _vesLeftLung
-    _totalLungVolume = _rightLungVolume + _leftLungVolume
-    
-    _functionalRightVolume = _venRightLung
-    _functionalLeftVolume = _venLeftLung
-    _functionalTotalVolume = _venRightLung + _venLeftLung
-
-    _affectedRightVolume = _infRightLung + _colRightLung + _bulRightLung
-    _affectedLeftVolume = _infLeftLung + _colLeftLung + _bulLeftLung
-    _affectedTotalVolume = _infRightLung + _colRightLung + _infLeftLung + _colLeftLung + _bulRightLung+ _bulLeftLung
-    
-    _rightLungVolumePerc = round(_rightLungVolume * 100. / _totalLungVolume)
-    _leftLungVolumePerc = round(_leftLungVolume * 100. / _totalLungVolume)
-    _totalLungVolumePerc = 100.
-    
-    _functionalRightVolumePerc = round(_functionalRightVolume * 100. / _rightLungVolume)
-    _functionalLeftVolumePerc = round(_functionalLeftVolume * 100. / _leftLungVolume)
-    _functionalTotalVolumePerc = round(_functionalTotalVolume * 100. / _totalLungVolume)
-
-    _affectedRightVolumePerc = round(_affectedRightVolume * 100. / _rightLungVolume)
-    _affectedLeftVolumePerc = round(_affectedLeftVolume * 100. / _leftLungVolume)
-    _affectedTotalVolumePerc = round(_affectedTotalVolume * 100. / _totalLungVolume)
-    
-    
-    _CovidQ = round(_affectedTotalVolume / _totalLungVolume,2)  
-    
-    
-    
-    if inccov_cb: 
-        covidTableNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLTableNode')
-        resTableNode = covidTableNode 
-        
-        
         column = resTableNode.AddColumn()
         column.SetName("Results")
         resTableNode.AddEmptyRow()
@@ -889,8 +819,7 @@ class CTLungAnalyzerLogic(ScriptedLoadableModuleLogic):
         resTableNode.SetCellText(9,col,str(_affectedLeftVolume))
         resTableNode.SetCellText(10,col,str(_affectedTotalVolume))
         resTableNode.SetCellText(12,col,str(_CovidQ))
-        
-        
+
         column3 = resTableNode.AddColumn()
         column3.SetName("%")
         col=2
@@ -903,107 +832,230 @@ class CTLungAnalyzerLogic(ScriptedLoadableModuleLogic):
         resTableNode.SetCellText(8,col,str(_affectedRightVolumePerc))
         resTableNode.SetCellText(9,col,str(_affectedLeftVolumePerc))
         resTableNode.SetCellText(10,col,str(_affectedTotalVolumePerc))
-     
-        resTableNode.Modified();
 
+        resTableNode.Modified()
+
+        return covidResultsTableNode
+
+    @property
+    def inputVolume(self):
+        return self.getParameterNode().GetNodeReference("InputVolume")
+
+    @inputVolume.setter
+    def inputVolume(self, node):
+        self.getParameterNode().SetNodeReferenceID("InputVolume", node.GetID() if node else None)
+
+    @property
+    def inputSegmentation(self):
+        return self.getParameterNode().GetNodeReference("InputSegmentation")
+
+    @inputSegmentation.setter
+    def inputSegmentation(self, node):
+        self.getParameterNode().SetNodeReferenceID("InputSegmentation", node.GetID() if node else None)
+
+    @property
+    def resultsTable(self):
+        return self.getParameterNode().GetNodeReference("ResultsTable")
+
+    @resultsTable.setter
+    def resultsTable(self, node):
+        self.getParameterNode().SetNodeReferenceID("ResultsTable", node.GetID() if node else None)
+
+    @property
+    def covidResultsTable(self):
+        return self.getParameterNode().GetNodeReference("CovidResultsTable")
+
+    @covidResultsTable.setter
+    def covidResultsTable(self, node):
+        self.getParameterNode().SetNodeReferenceID("CovidResultsTable", node.GetID() if node else None)
+
+    @property
+    def volumeRenderingPropertyNode(self):
+        return self.getParameterNode().GetNodeReference("VolumeRenderingPropertyNode")
+
+    @volumeRenderingPropertyNode.setter
+    def volumeRenderingPropertyNode(self, node):
+        self.getParameterNode().SetNodeReferenceID("VolumeRenderingPropertyNode", node.GetID() if node else None)
+
+    @property
+    def rightLungMaskSegmentID(self):
+      return self.getParameterNode().GetParameter("RightLungMaskSegmentID")
+
+    @rightLungMaskSegmentID.setter
+    def rightLungMaskSegmentID(self, value):
+        self.getParameterNode().SetParameter("RightLungMaskSegmentID", value)
+
+    @property
+    def leftLungMaskSegmentID(self):
+      return self.getParameterNode().GetParameter("LeftLungMaskSegmentID")
+
+    @leftLungMaskSegmentID.setter
+    def leftLungMaskSegmentID(self, value):
+        self.getParameterNode().SetParameter("LeftLungMaskSegmentID", value)
+
+    @property
+    def generateStatistics(self):
+      return self.getParameterNode().GetParameter("GenerateStatistics") == "true"
+
+    @generateStatistics.setter
+    def generateStatistics(self, on):
+        self.getParameterNode().SetParameter("GenerateStatistics", "true" if on else "false")
+
+    @property
+    def includeCovidEvaluation(self):
+      return self.getParameterNode().GetParameter("IncludeCovidEvaluation") == "true"
+
+    @includeCovidEvaluation.setter
+    def includeCovidEvaluation(self, on):
+        self.getParameterNode().SetParameter("IncludeCovidEvaluation", "true" if on else "false")
+
+    @property
+    def rightLungMaskedVolume(self):
+        return self.getParameterNode().GetNodeReference("RightLungMaskedVolume")
+
+    @rightLungMaskedVolume.setter
+    def rightLungMaskedVolume(self, node):
+        self.getParameterNode().SetNodeReferenceID("RightLungMaskedVolume", node.GetID() if node else None)
+
+    @property
+    def leftLungMaskedVolume(self):
+        return self.getParameterNode().GetNodeReference("LeftLungMaskedVolume")
+
+    @leftLungMaskedVolume.setter
+    def leftLungMaskedVolume(self, node):
+        self.getParameterNode().SetNodeReferenceID("LeftLungMaskedVolume", node.GetID() if node else None)
+
+    @property
+    def thresholds(self):
+        parameterNode = self.getParameterNode()
+        values = {}
+        for parameterName in self.defaultThresholds:
+            values[parameterName] = float(parameterNode.GetParameter(parameterName))
+        return values
+
+    @thresholds.setter
+    def thresholds(self, values):
+        parameterNode = self.getParameterNode()
+        wasModified = parameterNode.StartModify()
+        for parameterName in values:
+            parameterNode.SetParameter(parameterName, str(values[parameterName]))
+        parameterNode.EndModify(wasModified)
+
+    def process(self):
+        """
+        Run the processing algorithm.
+        Can be used without GUI widget.
+        """
+        logging.info('Processing started.')
+        import time
+        startTime = time.time()
+
+        # Validate inputs
+
+        parameterNode = self.getParameterNode()
+
+        inputVolume = parameterNode.GetNodeReference("InputVolume")
+        if not inputVolume:
+            raise ValueError("Input lung CT is invalid")
+
+        segmentationNode = parameterNode.GetNodeReference("InputSegmentation")
+        if not segmentationNode:
+            raise ValueError("Input lung segmentation node is invalid")
+
+        rightLungMaskSegmentID = self.rightLungMaskSegmentID
+        leftLungMaskSegmentID = self.leftLungMaskSegmentID
+        rightMaskSegmentName = segmentationNode.GetSegmentation().GetSegment(rightLungMaskSegmentID).GetName().upper()
+        leftMaskSegmentName = segmentationNode.GetSegmentation().GetSegment(leftLungMaskSegmentID).GetName().upper()
+        if ( (rightMaskSegmentName != "RIGHT LUNG" and rightMaskSegmentName != "RIGHT LUNG MASK") or
+            (leftMaskSegmentName != "LEFT LUNG" and leftMaskSegmentName != "LEFT LUNG MASK") ):
+            if not slicer.util.confirmYesNoDisplay("Warning: segment names are expected to be 'left/right lung' ('left/right lung mask'). Are you sure you want to continue?"):
+              raise UserWarning("User cancelled the analysis")
+
+        # Closed surface representation computation can take a long time - disable it (can be enabled later)
+        segmentationNode.RemoveClosedSurfaceRepresentation()
+
+        # Create masked volumes
+        self.createMaskedVolume("right", rightLungMaskSegmentID)
+        self.createMaskedVolume("left", leftLungMaskSegmentID)
+
+        # Create thresholded segments
+        self.createThresholdedSegments("right", rightLungMaskSegmentID)
+        self.createThresholdedSegments("left", leftLungMaskSegmentID)
+
+        # Compute analysis results table
+        self.createResultsTable()
+
+        # Compute Covid analysis results table
+        if self.includeCovidEvaluation:
+            self.createCovidResultsTable()
+
+        stopTime = time.time()
+        logging.info('Processing completed in {0:.2f} seconds'.format(stopTime-startTime))
+
+        self.rightLungMaskSegmentID = rightLungMaskSegmentID
+        self.leftLungMaskSegmentID = leftLungMaskSegmentID
+
+    def showTable(self, tableNode):
         currentLayout = slicer.app.layoutManager().layout
         layoutWithTable = slicer.modules.tables.logic().GetLayoutWithTable(currentLayout)
         slicer.app.layoutManager().setLayout(layoutWithTable)
-        slicer.app.applicationLogic().GetSelectionNode().SetActiveTableID(resTableNode.GetID())
+        slicer.app.applicationLogic().GetSelectionNode().SetActiveTableID(tableNode.GetID())
         slicer.app.applicationLogic().PropagateTableSelection()
-    
-    # center viewports
-    slicer.app.applicationLogic().FitSliceToAll()
-    # center 3D view
-    layoutManager = slicer.app.layoutManager()
-    threeDWidget = layoutManager.threeDWidget(0)
-    threeDView = threeDWidget.threeDView()
-    threeDView.resetFocalPoint()
-    # bug workaround
-    slicer.mrmlScene.RemoveNode(slicer.mrmlScene.GetFirstNodeByName('False lung masked volume'))
-    # ensure user sees the new segments
-    segmentationDisplayNode.Visibility2DOn()
-    if show3D_cb: 
-        # create 3D 
-        segmentationNode.CreateClosedSurfaceRepresentation()
-    
-    stopTime = time.time()
-    logging.info('Processing completed in {0:.2f} seconds'.format(stopTime-startTime))
+
 #
 # CTLungAnalyzerTest
 #
 
 class CTLungAnalyzerTest(ScriptedLoadableModuleTest):
-  """
-  This is the test case for your scripted module.
-  Uses ScriptedLoadableModuleTest base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
-  """
-
-  def setUp(self):
-    """ Do whatever is needed to reset the state - typically a scene clear will be enough.
     """
-    slicer.mrmlScene.Clear()
-
-  def runTest(self):
-    """Run as few or as many tests as needed here.
-    """
-    self.setUp()
-    self.test_CTLungAnalyzer1()
-
-  def test_CTLungAnalyzer1(self):
-    """ Ideally you should have several levels of tests.  At the lowest level
-    tests should exercise the functionality of the logic with different inputs
-    (both valid and invalid).  At higher levels your tests should emulate the
-    way the user would interact with your code and confirm that it still works
-    the way you intended.
-    One of the most important features of the tests is that it should alert other
-    developers when their changes will have an impact on the behavior of your
-    module.  For example, if a developer removes a feature that you depend on,
-    your test should break so they know that the feature is needed.
+    This is the test case for your scripted module.
+    Uses ScriptedLoadableModuleTest base class, available at:
+    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
-    self.delayDisplay("Starting the test")
+    def setUp(self):
+        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """
+        slicer.mrmlScene.Clear()
 
-    # Get/create input data
+    def runTest(self):
+        """Run as few or as many tests as needed here.
+        """
+        self.setUp()
+        self.test_CTLungAnalyzer1()
 
-    import SampleData
-    registerSampleData()
-    inputVolume = SampleData.downloadSample('DemoChestCT')
-    self.delayDisplay('Loaded demo chest CT.')
-    lungMaskSegmentation = SampleData.downloadSample('DemoLungMasks')
-    self.delayDisplay('Loaded demo lung masks.')
+    def test_CTLungAnalyzer1(self):
+        """ Ideally you should have several levels of tests.  At the lowest level
+        tests should exercise the functionality of the logic with different inputs
+        (both valid and invalid).  At higher levels your tests should emulate the
+        way the user would interact with your code and confirm that it still works
+        the way you intended.
+        One of the most important features of the tests is that it should alert other
+        developers when their changes will have an impact on the behavior of your
+        module.  For example, if a developer removes a feature that you depend on,
+        your test should break so they know that the feature is needed.
+        """
 
+        self.delayDisplay("Starting the test")
 
-    #outputVolume = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode")
+        # Get/create input data
 
-    # Test the module logic
+        import SampleData
+        registerSampleData()
+        inputVolume = SampleData.downloadSample('DemoChestCT')
+        self.delayDisplay('Loaded demo chest CT.')
+        lungMaskSegmentation = SampleData.downloadSample('DemoLungMasks')
+        self.delayDisplay('Loaded demo lung masks.')
 
-    logic = CTLungAnalyzerLogic()
+        # Test the module logic
+        logic = CTLungAnalyzerLogic()
+        logic.inputVolume = inputVolume
+        logic.inputSegmentation = lungMaskSegmentation
+        logic.rightLungMaskSegmentID = lungMaskSegmentation.GetSegmentation().GetSegmentIdBySegmentName("Right Lung Mask")
+        logic.leftLungMaskSegmentID = lungMaskSegmentation.GetSegmentation().GetSegmentIdBySegmentName("Left Lung Mask")
 
-    # Test algorithm with non-inverted threshold
-    
-    self.delayDisplay('Processing starts.')
-    logic.process(inputVolume,
-      lungMaskSegmentation,
-      lungMaskSegmentation,
-      lungMaskSegmentation.GetSegmentation().GetSegmentIdBySegmentName("Right Lung Mask"),
-      lungMaskSegmentation.GetSegmentation().GetSegmentIdBySegmentName("Left Lung Mask"),
-      -1000.,
-      -950.,
-      -950.,
-      -750.,
-      -750.,
-      -400.,
-      -400.,
-      400.,
-      400.,
-      1000.,
-      True,  # gen stat
-      True,  # delete prev seg
-      False, # COVID 
-      False) # 3D
- 
-    self.delayDisplay('Processing ends.')
+        self.delayDisplay('Processing starts.')
+        logic.process() # 3D
+        self.delayDisplay('Processing ends.')
 
-    self.delayDisplay('Test passed')
+        self.delayDisplay('Test passed')

--- a/CTLungAnalyzer/Resources/UI/CTLungAnalyzer.ui
+++ b/CTLungAnalyzer/Resources/UI/CTLungAnalyzer.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>335</width>
-    <height>957</height>
+    <height>715</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -75,6 +75,43 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_17">
+        <property name="toolTip">
+         <string>Lung CT volume that will be analyzed. Required.</string>
+        </property>
+        <property name="text">
+         <string>Input segmentation:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="qMRMLNodeComboBox" name="inputSegmentationSelector">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Pick a previously created lung segmentation here.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLSegmentationNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="0">
        <widget class="QLabel" name="label_10">
         <property name="text">
@@ -119,194 +156,9 @@
        </widget>
       </item>
       <item row="4" column="0">
-       <widget class="Line" name="line_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_17">
-        <property name="toolTip">
-         <string>Lung CT volume that will be analyzed. Required.</string>
-        </property>
-        <property name="text">
-         <string>Input segmentation:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="qMRMLNodeComboBox" name="inputSegmentationSelector">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="toolTip">
-         <string>Pick a previously created lung segmentation here.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist>
-          <string>vtkMRMLSegmentationNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="ctkCollapsibleButton" name="otutputOptionsCollapsibleButton">
-     <property name="text">
-      <string>Output options</string>
-     </property>
-     <property name="collapsed">
-      <bool>true</bool>
-     </property>
-     <layout class="QFormLayout" name="formLayout_3">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_13">
-        <property name="text">
-         <string>Right lung masked volume:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="qMRMLNodeComboBox" name="rightLungMaskedVolumeSelector">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="toolTip">
-         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist>
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="editEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="renameEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="noneDisplay">
-         <string>Create new volume</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_14">
-        <property name="text">
-         <string>Left lung masked volume:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="qMRMLNodeComboBox" name="leftLungMaskedVolumeSelector">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="toolTip">
-         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist>
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="editEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="renameEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="noneDisplay">
-         <string>Create new volume</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_15">
-        <property name="text">
-         <string>Results table:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="qMRMLNodeComboBox" name="outputResultsTableSelector">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="toolTip">
-         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist>
-          <string>vtkMRMLTableNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="editEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="renameEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="noneDisplay">
-         <string>Create new table</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Compute Image intensity statistics: </string>
+         <string>Density statistics: </string>
         </property>
        </widget>
       </item>
@@ -323,121 +175,47 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0" colspan="2">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>BETA, do not use for clinical decision making: </string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="label_12">
         <property name="text">
-         <string>Include COVID-19 evaluation: </string>
-        </property>
-        <property name="indent">
-         <number>10</number>
+         <string>COVID-19 evaluation: </string>
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="5" column="1">
        <widget class="QCheckBox" name="includeCovidEvaluationCheckBox">
         <property name="toolTip">
          <string>Check this to include an extended result table. </string>
         </property>
         <property name="text">
-         <string/>
+         <string>Not for clinical decision making!</string>
         </property>
        </widget>
       </item>
       <item row="7" column="0">
-       <widget class="QLabel" name="label_16">
-        <property name="text">
-         <string>COVID-19 results table:</string>
-        </property>
-        <property name="indent">
-         <number>10</number>
+       <widget class="Line" name="line_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="7" column="1">
-       <widget class="qMRMLNodeComboBox" name="outputCovidResultsTableSelector">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="toolTip">
-         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist>
-          <string>vtkMRMLTableNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="editEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="renameEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="noneDisplay">
-         <string>Create new table</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="qMRMLNodeComboBox" name="volumeRenderingPropertyNodeSelector">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="toolTip">
-         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist>
-          <string>vtkMRMLVolumePropertyNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="editEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="renameEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="noneDisplay">
-         <string>Create new property</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_23">
-        <property name="text">
-         <string>Volume rendering property:</string>
-        </property>
-       </widget>
+      <item row="6" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QPushButton" name="toggleInputSegmentationVisibility2DPushButton">
+          <property name="text">
+           <string>Show/hide segments in 2D</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="toggleInputSegmentationVisibility3DPushButton">
+          <property name="text">
+           <string>Show/hide segments in 3D</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -615,114 +393,41 @@
         </item>
        </layout>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QPushButton" name="applyButton">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="toolTip">
-      <string>Run the algorithm.</string>
-     </property>
-     <property name="text">
-      <string>Apply</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox">
-     <property name="title">
-      <string>Display </string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="1">
-       <widget class="QPushButton" name="showSegmentsIn3DPushButton">
-        <property name="text">
-         <string>Show segments in 3D</string>
-        </property>
-       </widget>
+      <item row="6" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QPushButton" name="toggleMaskedVolumeDisplay2DPushButton">
+          <property name="text">
+           <string>Show/hide preview in 2D</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="toggleMaskedVolumeDisplay3DPushButton">
+          <property name="text">
+           <string>Show/hide preview in 3D</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="0" column="0">
-       <widget class="QPushButton" name="showResultsTablePushButton">
-        <property name="text">
-         <string>Show results table</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QPushButton" name="toggleSegmentsVisibility">
-        <property name="toolTip">
-         <string>Press this button to enable or disable the display of the newly created segments in 2D view. </string>
-        </property>
-        <property name="text">
-         <string>Show/hide segments</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="showCovidResultsTableButton">
-        <property name="text">
-         <string>Show COVID-19 results table</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
+      <item row="7" column="0" colspan="2">
        <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox_2">
         <property name="title">
-         <string>Volume rendering</string>
+         <string>Volume rendering opacities</string>
+        </property>
+        <property name="collapsed">
+         <bool>true</bool>
         </property>
         <layout class="QFormLayout" name="formLayout">
-         <item row="2" column="0">
+         <item row="1" column="0">
           <widget class="QLabel" name="label_18">
            <property name="text">
             <string>Bulla / Pneu</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="label_19">
-           <property name="text">
-            <string>Ventilated</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="label_20">
-           <property name="text">
-            <string>Infiltrated</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="label_21">
-           <property name="text">
-            <string>Collapsed</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="label_22">
-           <property name="text">
-            <string>Vessels</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
+         <item row="1" column="1">
           <widget class="ctkSliderWidget" name="bullaOpacityWidget">
            <property name="toolTip">
             <string>Volume rendering opacity</string>
@@ -747,7 +452,14 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_19">
+           <property name="text">
+            <string>Ventilated</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
           <widget class="ctkSliderWidget" name="ventilatedOpacityWidget">
            <property name="toolTip">
             <string>Volume rendering opacity</string>
@@ -772,7 +484,14 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_20">
+           <property name="text">
+            <string>Infiltrated</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
           <widget class="ctkSliderWidget" name="infiltratedOpacityWidget">
            <property name="toolTip">
             <string>Volume rendering opacity</string>
@@ -797,7 +516,14 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="1">
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_21">
+           <property name="text">
+            <string>Collapsed</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
           <widget class="ctkSliderWidget" name="collapsedOpacityWidget">
            <property name="toolTip">
             <string>Volume rendering opacity</string>
@@ -822,7 +548,14 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_22">
+           <property name="text">
+            <string>Vessels</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
           <widget class="ctkSliderWidget" name="vesselsOpacityWidget">
            <property name="toolTip">
             <string>Volume rendering opacity</string>
@@ -847,25 +580,300 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0" colspan="2">
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <item>
-            <widget class="QPushButton" name="toggleRightVolumeRenderingPushButton">
-             <property name="text">
-              <string>Show/hide right lung</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="toggleLeftVolumeRenderingPushButton">
-             <property name="text">
-              <string>Show/hide left lung</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
         </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="CollapsibleButton">
+     <property name="text">
+      <string>Statistics</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="1">
+       <widget class="QPushButton" name="showCovidResultsTableButton">
+        <property name="text">
+         <string>Show COVID-19 results table</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="showResultsTablePushButton">
+        <property name="text">
+         <string>Show results table</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QPushButton" name="applyButton">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Run the algorithm.</string>
+        </property>
+        <property name="text">
+         <string>Compute results</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QPushButton" name="toggleOutputSegmentationVisibility2DPushButton">
+        <property name="toolTip">
+         <string>Press this button to enable or disable the display of the newly created segments in 2D view. </string>
+        </property>
+        <property name="text">
+         <string>Show/hide segments in 2D</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QPushButton" name="toggleOutputSegmentationVisibility3DPushButton">
+        <property name="text">
+         <string>Show/hide segments in 3D</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="otutputOptionsCollapsibleButton">
+     <property name="text">
+      <string>Advanced</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QFormLayout" name="formLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_13">
+        <property name="text">
+         <string>Masked lung CT:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="qMRMLNodeComboBox" name="lungMaskedVolumeSelector">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLScalarVolumeNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new volume</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_14">
+        <property name="text">
+         <string>Output segmentation:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="qMRMLNodeComboBox" name="outputSegmentationSelector">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLSegmentationNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new volume</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_15">
+        <property name="text">
+         <string>Results table:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="qMRMLNodeComboBox" name="outputResultsTableSelector">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLTableNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new table</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_16">
+        <property name="text">
+         <string>COVID-19 results table:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="qMRMLNodeComboBox" name="outputCovidResultsTableSelector">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLTableNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new table</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="qMRMLNodeComboBox" name="volumeRenderingPropertyNodeSelector">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLVolumePropertyNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new property</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_23">
+        <property name="text">
+         <string>Volume rendering property:</string>
+        </property>
        </widget>
       </item>
      </layout>
@@ -970,12 +978,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>327</x>
-     <y>373</y>
+     <x>261</x>
+     <y>198</y>
     </hint>
     <hint type="destinationlabel">
      <x>327</x>
-     <y>400</y>
+     <y>688</y>
     </hint>
    </hints>
   </connection>
@@ -998,7 +1006,7 @@
   <connection>
    <sender>CTLungAnalyzer</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>rightLungMaskedVolumeSelector</receiver>
+   <receiver>lungMaskedVolumeSelector</receiver>
    <slot>setMRMLScene(vtkMRMLScene*)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -1006,15 +1014,15 @@
      <y>5</y>
     </hint>
     <hint type="destinationlabel">
-     <x>219</x>
-     <y>219</y>
+     <x>179</x>
+     <y>678</y>
     </hint>
    </hints>
   </connection>
   <connection>
    <sender>CTLungAnalyzer</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>leftLungMaskedVolumeSelector</receiver>
+   <receiver>outputSegmentationSelector</receiver>
    <slot>setMRMLScene(vtkMRMLScene*)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -1022,8 +1030,8 @@
      <y>366</y>
     </hint>
     <hint type="destinationlabel">
-     <x>327</x>
-     <y>250</y>
+     <x>287</x>
+     <y>679</y>
     </hint>
    </hints>
   </connection>
@@ -1038,8 +1046,8 @@
      <y>398</y>
     </hint>
     <hint type="destinationlabel">
-     <x>327</x>
-     <y>277</y>
+     <x>287</x>
+     <y>681</y>
     </hint>
    </hints>
   </connection>
@@ -1054,8 +1062,8 @@
      <y>300</y>
     </hint>
     <hint type="destinationlabel">
-     <x>301</x>
-     <y>302</y>
+     <x>261</x>
+     <y>682</y>
     </hint>
    </hints>
   </connection>

--- a/CTLungAnalyzer/Resources/UI/CTLungAnalyzer.ui
+++ b/CTLungAnalyzer/Resources/UI/CTLungAnalyzer.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>335</width>
+    <width>329</width>
     <height>715</height>
    </rect>
   </property>
@@ -674,7 +674,7 @@
          <bool>true</bool>
         </property>
         <property name="toolTip">
-         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
+         <string>Node that stores the masked CT (where areas outside the lungs are blanked out)</string>
         </property>
         <property name="nodeTypes">
          <stringlist>
@@ -705,141 +705,19 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_14">
+       <widget class="QLabel" name="label_23">
         <property name="text">
-         <string>Output segmentation:</string>
+         <string>Volume rendering property:</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="qMRMLNodeComboBox" name="outputSegmentationSelector">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="toolTip">
-         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist>
-          <string>vtkMRMLSegmentationNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="editEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="renameEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="noneDisplay">
-         <string>Create new volume</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_15">
-        <property name="text">
-         <string>Results table:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="qMRMLNodeComboBox" name="outputResultsTableSelector">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="toolTip">
-         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist>
-          <string>vtkMRMLTableNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="editEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="renameEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="noneDisplay">
-         <string>Create new table</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="label_16">
-        <property name="text">
-         <string>COVID-19 results table:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <widget class="qMRMLNodeComboBox" name="outputCovidResultsTableSelector">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="toolTip">
-         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist>
-          <string>vtkMRMLTableNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="editEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="renameEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="noneDisplay">
-         <string>Create new table</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
        <widget class="qMRMLNodeComboBox" name="volumeRenderingPropertyNodeSelector">
         <property name="enabled">
          <bool>true</bool>
         </property>
         <property name="toolTip">
-         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
+         <string>Stores volume rendering settings for 3D preview.</string>
         </property>
         <property name="nodeTypes">
          <stringlist>
@@ -869,10 +747,132 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_23">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_14">
         <property name="text">
-         <string>Volume rendering property:</string>
+         <string>Output segmentation:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="qMRMLNodeComboBox" name="outputSegmentationSelector">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Segmentation node that stores the created segmentation</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLSegmentationNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new volume</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_15">
+        <property name="text">
+         <string>Results table:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="qMRMLNodeComboBox" name="outputResultsTableSelector">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Table node that stores volumetric analysis results</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLTableNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new table</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_16">
+        <property name="text">
+         <string>COVID-19 results table:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="qMRMLNodeComboBox" name="outputCovidResultsTableSelector">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Table that stores COVID-19 analysis results</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLTableNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new table</string>
         </property>
        </widget>
       </item>
@@ -882,6 +882,22 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSegmentSelectorWidget</class>
+   <extends>qMRMLWidget</extends>
+   <header>qMRMLSegmentSelectorWidget.h</header>
+  </customwidget>
   <customwidget>
    <class>ctkCollapsibleButton</class>
    <extends>QWidget</extends>
@@ -904,22 +920,6 @@
    <extends>QWidget</extends>
    <header>ctkSliderWidget.h</header>
   </customwidget>
-  <customwidget>
-   <class>qMRMLNodeComboBox</class>
-   <extends>QWidget</extends>
-   <header>qMRMLNodeComboBox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLWidget</class>
-   <extends>QWidget</extends>
-   <header>qMRMLWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLSegmentSelectorWidget</class>
-   <extends>qMRMLWidget</extends>
-   <header>qMRMLSegmentSelectorWidget.h</header>
-  </customwidget>
  </customwidgets>
  <resources/>
  <connections>
@@ -934,8 +934,8 @@
      <y>132</y>
     </hint>
     <hint type="destinationlabel">
-     <x>327</x>
-     <y>81</y>
+     <x>316</x>
+     <y>84</y>
     </hint>
    </hints>
   </connection>
@@ -950,8 +950,8 @@
      <y>382</y>
     </hint>
     <hint type="destinationlabel">
-     <x>327</x>
-     <y>139</y>
+     <x>316</x>
+     <y>123</y>
     </hint>
    </hints>
   </connection>
@@ -966,24 +966,8 @@
      <y>402</y>
     </hint>
     <hint type="destinationlabel">
-     <x>327</x>
-     <y>159</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>includeCovidEvaluationCheckBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>outputCovidResultsTableSelector</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>261</x>
-     <y>198</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>327</x>
-     <y>688</y>
+     <x>316</x>
+     <y>143</y>
     </hint>
    </hints>
   </connection>
@@ -998,8 +982,8 @@
      <y>9</y>
     </hint>
     <hint type="destinationlabel">
-     <x>179</x>
-     <y>109</y>
+     <x>312</x>
+     <y>104</y>
     </hint>
    </hints>
   </connection>
@@ -1014,8 +998,8 @@
      <y>5</y>
     </hint>
     <hint type="destinationlabel">
-     <x>179</x>
-     <y>678</y>
+     <x>316</x>
+     <y>596</y>
     </hint>
    </hints>
   </connection>
@@ -1030,8 +1014,8 @@
      <y>366</y>
     </hint>
     <hint type="destinationlabel">
-     <x>287</x>
-     <y>679</y>
+     <x>316</x>
+     <y>646</y>
     </hint>
    </hints>
   </connection>
@@ -1046,8 +1030,8 @@
      <y>398</y>
     </hint>
     <hint type="destinationlabel">
-     <x>287</x>
-     <y>681</y>
+     <x>316</x>
+     <y>671</y>
     </hint>
    </hints>
   </connection>
@@ -1062,8 +1046,24 @@
      <y>300</y>
     </hint>
     <hint type="destinationlabel">
-     <x>261</x>
-     <y>682</y>
+     <x>316</x>
+     <y>621</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>CTLungAnalyzer</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>outputCovidResultsTableSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>327</x>
+     <y>687</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>293</x>
+     <y>689</y>
     </hint>
    </hints>
   </connection>

--- a/CTLungAnalyzer/Resources/UI/CTLungAnalyzer.ui
+++ b/CTLungAnalyzer/Resources/UI/CTLungAnalyzer.ui
@@ -6,91 +6,159 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>507</width>
-    <height>844</height>
+    <width>335</width>
+    <height>957</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="label_8">
-     <property name="text">
-      <string>Lung CT Analyzer V 1.2</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Lung CT Analyzer V 1.2</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="downloadCovidDataButton">
+       <property name="toolTip">
+        <string>Pressing this button will download a COVID-19 demo dataset. All currently loaded data will be erased. </string>
+       </property>
+       <property name="text">
+        <string>Load demo COVID-19 data</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="advancedCollapsibleButton">
+    <widget class="ctkCollapsibleButton" name="inputsCollapsibleButton">
      <property name="text">
-      <string>Advanced</string>
+      <string>Input image and segmentation</string>
      </property>
-     <property name="collapsed">
-      <bool>false</bool>
-     </property>
-     <layout class="QFormLayout" name="formLayout_3">
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="generateStatisticsCheckBox">
+     <layout class="QFormLayout" name="formLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
         <property name="toolTip">
-         <string>Check this to generate a statistics table. </string>
+         <string>Lung CT volume that will be analyzed. Required.</string>
         </property>
         <property name="text">
-         <string>generate statistics</string>
+         <string>Input lung CT:</string>
         </property>
-        <property name="checked">
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="qMRMLNodeComboBox" name="inputVolumeSelector">
+        <property name="enabled">
          <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLScalarVolumeNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>false</bool>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QCheckBox" name="deletePreviousSegmentationsCheckBox">
-        <property name="toolTip">
-         <string>Check this if you want to always delete the previous segmentations to avoid cluttering of your storage node. </string>
-        </property>
+       <widget class="QLabel" name="label_10">
         <property name="text">
-         <string>delete previous segmentations</string>
+         <string>Right Lung</string>
         </property>
-        <property name="checked">
+        <property name="indent">
+         <number>20</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="qMRMLSegmentSelectorWidget" name="rightLungMaskSelector">
+        <property name="toolTip">
+         <string>Pick a previously created right lung mask here. </string>
+        </property>
+        <property name="segmentationNodeSelectorVisible">
+         <bool>false</bool>
+        </property>
+        <property name="selectNodeUponCreation">
          <bool>true</bool>
         </property>
        </widget>
       </item>
       <item row="3" column="0">
-       <widget class="QCheckBox" name="show3DCheckBox">
-        <property name="toolTip">
-         <string>Check this to display the final results as a spatial reconstruction. This will prolong the calculations to about 1-2 minutes. </string>
-        </property>
+       <widget class="QLabel" name="label_11">
         <property name="text">
-         <string>Show result in 3D (longer waiting time)</string>
+         <string>Left Lung</string>
+        </property>
+        <property name="indent">
+         <number>20</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="qMRMLSegmentSelectorWidget" name="leftLungMaskSelector">
+        <property name="toolTip">
+         <string>Pick a previously created left lung mask here</string>
+        </property>
+        <property name="segmentationNodeSelectorVisible">
+         <bool>false</bool>
         </property>
        </widget>
       </item>
       <item row="4" column="0">
-       <widget class="Line" name="line">
+       <widget class="Line" name="line_3">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="Line" name="line_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>BETA, do not use for clinical decision making: </string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0" colspan="2">
-       <widget class="QCheckBox" name="includeCovidEvaluationCheckBox">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_17">
         <property name="toolTip">
-         <string>Check this to include an extended result table. </string>
+         <string>Lung CT volume that will be analyzed. Required.</string>
         </property>
         <property name="text">
-         <string>include COVID-19 evaluation </string>
+         <string>Input segmentation:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="qMRMLNodeComboBox" name="inputSegmentationSelector">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Pick a previously created lung segmentation here.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLSegmentationNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>false</bool>
         </property>
        </widget>
       </item>
@@ -98,20 +166,23 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="inputsCollapsibleButton">
+    <widget class="ctkCollapsibleButton" name="otutputOptionsCollapsibleButton">
      <property name="text">
-      <string>Inputs</string>
+      <string>Output options</string>
      </property>
-     <layout class="QFormLayout" name="formLayout_2">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QFormLayout" name="formLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_13">
         <property name="text">
-         <string>Input volume (*)</string>
+         <string>Right lung masked volume:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="qMRMLNodeComboBox" name="inputVolumeSelector">
+      <item row="0" column="1">
+       <widget class="qMRMLNodeComboBox" name="rightLungMaskedVolumeSelector">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -133,80 +204,261 @@
          <bool>false</bool>
         </property>
         <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new volume</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_14">
+        <property name="text">
+         <string>Left lung masked volume:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="qMRMLNodeComboBox" name="leftLungMaskedVolumeSelector">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLScalarVolumeNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
          <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new volume</string>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QLabel" name="label_10">
+       <widget class="QLabel" name="label_15">
         <property name="text">
-         <string>Right lung mask (*)</string>
+         <string>Results table:</string>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="qMRMLSegmentSelectorWidget" name="rightLungMaskSelector">
-        <property name="toolTip">
-         <string>Pick a previously created right lung mask here. </string>
-        </property>
-        <property name="segmentationNodeSelectorVisible">
+       <widget class="qMRMLNodeComboBox" name="outputResultsTableSelector">
+        <property name="enabled">
          <bool>true</bool>
         </property>
-        <property name="selectNodeUponCreation">
+        <property name="toolTip">
+         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLTableNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
          <bool>true</bool>
         </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_11">
-        <property name="text">
-         <string>Left lung mask (*)</string>
+        <property name="addEnabled">
+         <bool>false</bool>
         </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="qMRMLSegmentSelectorWidget" name="leftLungMaskSelector">
-        <property name="toolTip">
-         <string>Pick a previously created left lung mask here</string>
+        <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new table</string>
         </property>
        </widget>
       </item>
       <item row="4" column="0">
-       <widget class="QLabel" name="label_12">
+       <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>(*) = mandatory</string>
+         <string>Compute Image intensity statistics: </string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="Line" name="line_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+      <item row="4" column="1">
+       <widget class="QCheckBox" name="generateStatisticsCheckBox">
+        <property name="toolTip">
+         <string>Check this to generate a statistics table. </string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
-       <widget class="Line" name="line_4">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+      <item row="5" column="0" colspan="2">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>BETA, do not use for clinical decision making: </string>
         </property>
        </widget>
       </item>
       <item row="6" column="0">
-       <widget class="QLabel" name="label_6">
+       <widget class="QLabel" name="label_12">
         <property name="text">
-         <string>Thresholds</string>
+         <string>Include COVID-19 evaluation: </string>
+        </property>
+        <property name="indent">
+         <number>10</number>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QCheckBox" name="includeCovidEvaluationCheckBox">
+        <property name="toolTip">
+         <string>Check this to include an extended result table. </string>
+        </property>
+        <property name="text">
+         <string/>
         </property>
        </widget>
       </item>
       <item row="7" column="0">
+       <widget class="QLabel" name="label_16">
+        <property name="text">
+         <string>COVID-19 results table:</string>
+        </property>
+        <property name="indent">
+         <number>10</number>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="qMRMLNodeComboBox" name="outputCovidResultsTableSelector">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLTableNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new table</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="qMRMLNodeComboBox" name="volumeRenderingPropertyNodeSelector">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Pick the input volume (the chest CT volume) to the algorithm.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLVolumePropertyNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new property</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_23">
+        <property name="text">
+         <string>Volume rendering property:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="thresholdsCollapsibleButton">
+     <property name="text">
+      <string>Thresholds</string>
+     </property>
+     <property name="collapsed">
+      <bool>false</bool>
+     </property>
+     <layout class="QFormLayout" name="formLayout_4">
+      <item row="0" column="0">
        <widget class="QLabel" name="label_7">
         <property name="text">
          <string>Bulla / Pneu</string>
         </property>
        </widget>
       </item>
-      <item row="7" column="1">
+      <item row="0" column="1">
        <widget class="ctkRangeWidget" name="BullaRangeWidget">
         <property name="singleStep">
          <double>10.000000000000000</double>
@@ -225,14 +477,14 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>Ventilated</string>
         </property>
        </widget>
       </item>
-      <item row="8" column="1">
+      <item row="1" column="1">
        <widget class="ctkRangeWidget" name="VentilatedRangeWidget">
         <property name="singleStep">
          <double>10.000000000000000</double>
@@ -251,14 +503,14 @@
         </property>
        </widget>
       </item>
-      <item row="9" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
          <string>Infiltrated</string>
         </property>
        </widget>
       </item>
-      <item row="9" column="1">
+      <item row="2" column="1">
        <widget class="ctkRangeWidget" name="InfiltratedRangeWidget">
         <property name="singleStep">
          <double>10.000000000000000</double>
@@ -277,14 +529,14 @@
         </property>
        </widget>
       </item>
-      <item row="11" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
          <string>Collapsed</string>
         </property>
        </widget>
       </item>
-      <item row="11" column="1">
+      <item row="3" column="1">
        <widget class="ctkRangeWidget" name="CollapsedRangeWidget">
         <property name="singleStep">
          <double>10.000000000000000</double>
@@ -303,14 +555,14 @@
         </property>
        </widget>
       </item>
-      <item row="12" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="label_9">
         <property name="text">
          <string>Vessels</string>
         </property>
        </widget>
       </item>
-      <item row="12" column="1">
+      <item row="4" column="1">
        <widget class="ctkRangeWidget" name="VesselsRangeWidget">
         <property name="singleStep">
          <double>10.000000000000000</double>
@@ -329,74 +581,39 @@
         </property>
        </widget>
       </item>
-      <item row="13" column="0">
-       <widget class="QPushButton" name="restoreDefaultsButton">
-        <property name="toolTip">
-         <string>Press this button to restore the threshold sliders to their default positions. </string>
-        </property>
-        <property name="text">
-         <string>Restore defaults</string>
-        </property>
-       </widget>
-      </item>
-      <item row="14" column="0">
-       <widget class="QPushButton" name="saveThresholdsButton">
-        <property name="toolTip">
-         <string>Press this button to save the current position of the threshold buttons. </string>
-        </property>
-        <property name="text">
-         <string>Save Thresholds</string>
-        </property>
-       </widget>
-      </item>
-      <item row="15" column="0">
-       <widget class="QPushButton" name="loadThresholdsButton">
-        <property name="toolTip">
-         <string>Press this button to load the previously saved  positions of the threshold buttons. </string>
-        </property>
-        <property name="text">
-         <string>Load Thresholds</string>
-        </property>
-       </widget>
-      </item>
-      <item row="17" column="0">
-       <widget class="QPushButton" name="segmentsOnOffButton">
-        <property name="toolTip">
-         <string>Press this button to enable or disable the display of the newly created segments in 2D view. </string>
-        </property>
-        <property name="text">
-         <string>Segments on/off</string>
-        </property>
-       </widget>
-      </item>
-      <item row="18" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="13" column="1">
-       <widget class="QPushButton" name="dwnlCOVIDDataButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Ignored">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Pressing this button will download a COVID-19 demo dataset. All currently loaded data will be erased. </string>
-        </property>
-        <property name="text">
-         <string>Demo COVID Data</string>
-        </property>
-       </widget>
+      <item row="5" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QPushButton" name="loadThresholdsButton">
+          <property name="toolTip">
+           <string>Press this button to load the previously saved  positions of the threshold buttons. </string>
+          </property>
+          <property name="text">
+           <string>Load preset</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="saveThresholdsButton">
+          <property name="toolTip">
+           <string>Press this button to save the current position of the threshold buttons. </string>
+          </property>
+          <property name="text">
+           <string>Save preset</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="restoreDefaultsButton">
+          <property name="toolTip">
+           <string>Press this button to reset the threshold sliders to their default positions.</string>
+          </property>
+          <property name="text">
+           <string>Reset to default</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -414,6 +631,246 @@
      </property>
     </widget>
    </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox">
+     <property name="title">
+      <string>Display </string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="1" column="1">
+       <widget class="QPushButton" name="showSegmentsIn3DPushButton">
+        <property name="text">
+         <string>Show segments in 3D</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QPushButton" name="showResultsTablePushButton">
+        <property name="text">
+         <string>Show results table</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="toggleSegmentsVisibility">
+        <property name="toolTip">
+         <string>Press this button to enable or disable the display of the newly created segments in 2D view. </string>
+        </property>
+        <property name="text">
+         <string>Show/hide segments</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="showCovidResultsTableButton">
+        <property name="text">
+         <string>Show COVID-19 results table</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox_2">
+        <property name="title">
+         <string>Volume rendering</string>
+        </property>
+        <layout class="QFormLayout" name="formLayout">
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_18">
+           <property name="text">
+            <string>Bulla / Pneu</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_19">
+           <property name="text">
+            <string>Ventilated</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_20">
+           <property name="text">
+            <string>Infiltrated</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_21">
+           <property name="text">
+            <string>Collapsed</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="label_22">
+           <property name="text">
+            <string>Vessels</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="ctkSliderWidget" name="bullaOpacityWidget">
+           <property name="toolTip">
+            <string>Volume rendering opacity</string>
+           </property>
+           <property name="decimals">
+            <number>1</number>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="pageStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>20.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>0.000000000000000</double>
+           </property>
+           <property name="suffix">
+            <string>%</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="ctkSliderWidget" name="ventilatedOpacityWidget">
+           <property name="toolTip">
+            <string>Volume rendering opacity</string>
+           </property>
+           <property name="decimals">
+            <number>1</number>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="pageStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>20.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>0.500000000000000</double>
+           </property>
+           <property name="suffix">
+            <string>%</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="ctkSliderWidget" name="infiltratedOpacityWidget">
+           <property name="toolTip">
+            <string>Volume rendering opacity</string>
+           </property>
+           <property name="decimals">
+            <number>1</number>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="pageStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>20.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="suffix">
+            <string>%</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="ctkSliderWidget" name="collapsedOpacityWidget">
+           <property name="toolTip">
+            <string>Volume rendering opacity</string>
+           </property>
+           <property name="decimals">
+            <number>1</number>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="pageStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>20.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="suffix">
+            <string>%</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="ctkSliderWidget" name="vesselsOpacityWidget">
+           <property name="toolTip">
+            <string>Volume rendering opacity</string>
+           </property>
+           <property name="decimals">
+            <number>1</number>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="pageStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>20.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="suffix">
+            <string>%</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0" colspan="2">
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <item>
+            <widget class="QPushButton" name="toggleRightVolumeRenderingPushButton">
+             <property name="text">
+              <string>Show/hide right lung</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="toggleLeftVolumeRenderingPushButton">
+             <property name="text">
+              <string>Show/hide left lung</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -424,9 +881,20 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>ctkCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>ctkCollapsibleGroupBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>ctkRangeWidget</class>
    <extends>QWidget</extends>
    <header>ctkRangeWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkSliderWidget.h</header>
   </customwidget>
   <customwidget>
    <class>qMRMLNodeComboBox</class>
@@ -458,8 +926,8 @@
      <y>132</y>
     </hint>
     <hint type="destinationlabel">
-     <x>384</x>
-     <y>313</y>
+     <x>327</x>
+     <y>81</y>
     </hint>
    </hints>
   </connection>
@@ -474,8 +942,8 @@
      <y>382</y>
     </hint>
     <hint type="destinationlabel">
-     <x>310</x>
-     <y>340</y>
+     <x>327</x>
+     <y>139</y>
     </hint>
    </hints>
   </connection>
@@ -490,8 +958,104 @@
      <y>402</y>
     </hint>
     <hint type="destinationlabel">
-     <x>310</x>
-     <y>387</y>
+     <x>327</x>
+     <y>159</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>includeCovidEvaluationCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>outputCovidResultsTableSelector</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>327</x>
+     <y>373</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>327</x>
+     <y>400</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>CTLungAnalyzer</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>inputSegmentationSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>176</x>
+     <y>9</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>179</x>
+     <y>109</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>CTLungAnalyzer</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>rightLungMaskedVolumeSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>233</x>
+     <y>5</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>219</x>
+     <y>219</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>CTLungAnalyzer</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>leftLungMaskedVolumeSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>345</x>
+     <y>366</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>327</x>
+     <y>250</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>CTLungAnalyzer</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>outputResultsTableSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>345</x>
+     <y>398</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>327</x>
+     <y>277</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>CTLungAnalyzer</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>volumeRenderingPropertyNodeSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>341</x>
+     <y>300</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>301</x>
+     <y>302</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
Added real-time preview of coloring (using dynamically adjusted color transfer functions in slice views and in volume rendering).

Also made the code and GUI simpler and more conform to 3D Slicer conventions, improved performance, and implemented saving of all settings into the scene (so that a study can be saved and reloaded).

Overview of the revamped module:

https://youtu.be/0plsoy94hFE

Have a look at the changed CovidQ computation, I've changed it, as this seemed to be incorrect (it should have been affected/functional, according to the label):

https://github.com/rbumm/SlicerCTLungAnalyzer/blob/1811dd8b0d4f53e43a82e11f50399c06d5429492/CTLungAnalyzer/CTLungAnalyzer.py#L843