### PR TITLE
ENH: standardize airway thresholds

### DIFF
--- a/LungCTSegmenter/LungCTSegmenter.py
+++ b/LungCTSegmenter/LungCTSegmenter.py
@@ -94,8 +94,6 @@ class LungCTSegmenterWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       
       self.lungThresholdMin = 0.
       self.lungThresholdMax = 0. 
-      self.airwayThresholdMin = 0.
-      self.airwayThresholdMax = 0.
       self.vesselThresholdMin = 0.
       self.vesselThresholdMax = 0.
 
@@ -180,7 +178,6 @@ class LungCTSegmenterWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       
       # Connect threshold range sliders 
       self.ui.LungThresholdRangeWidget.connect('valuesChanged(double,double)', self.onLungThresholdRangeWidgetChanged)
-      self.ui.AirwayThresholdRangeWidget.connect('valuesChanged(double,double)', self.onAirwayThresholdRangeWidgetChanged)
       self.ui.VesselThresholdRangeWidget.connect('valuesChanged(double,double)', self.onVesselThresholdRangeWidgetChanged)
 
       # Connect double sliders 
@@ -232,10 +229,6 @@ class LungCTSegmenterWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.LungThresholdRangeWidget.minimumValue = self.lungThresholdMin = float(settings.value("LungCtSegmenter/lungThresholdRangeMinimumValue", ""))  
       if settings.value("LungCtSegmenter/lungThresholdRangeMaximumValue", "") != "":               
         self.ui.LungThresholdRangeWidget.maximumValue = self.lungThresholdMax =  float(settings.value("LungCtSegmenter/lungThresholdRangeMaximumValue", ""))
-      if settings.value("LungCtSegmenter/airwayThresholdRangeMinimumValue", "") != "":               
-        self.ui.AirwayThresholdRangeWidget.minimumValue = self.airwayThresholdMin =  float(settings.value("LungCtSegmenter/airwayThresholdRangeMinimumValue", ""))
-      if settings.value("LungCtSegmenter/airwayThresholdRangeMaximumValue", "") != "":               
-        self.ui.AirwayThresholdRangeWidget.maximumValue = self.airwayThresholdMax =  float(settings.value("LungCtSegmenter/airwayThresholdRangeMaximumValue", ""))
 
       if settings.value("LungCtSegmenter/vesselThresholdRangeMinimumValue", "") != "":               
         self.ui.VesselThresholdRangeWidget.minimumValue = self.vesselThresholdMin =  float(settings.value("LungCtSegmenter/vesselThresholdRangeMinimumValue", ""))
@@ -329,8 +322,6 @@ class LungCTSegmenterWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       self.ui.VolumeRenderingShiftSliderWidget.value = 0
       self.ui.LungThresholdRangeWidget.minimumValue = -1500
       self.ui.LungThresholdRangeWidget.maximumValue = -400
-      self.ui.AirwayThresholdRangeWidget.minimumValue = -1500
-      self.ui.AirwayThresholdRangeWidget.maximumValue = -700
       self.ui.VesselThresholdRangeWidget.minimumValue = -0
       self.ui.VesselThresholdRangeWidget.maximumValue = 3000
       self.updateParameterNodeFromGUI()
@@ -521,9 +512,6 @@ class LungCTSegmenterWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def onLungThresholdRangeWidgetChanged(self):
        self.updateParameterNodeFromGUI()
       
-  def onAirwayThresholdRangeWidgetChanged(self):
-       self.updateParameterNodeFromGUI()
-
   def onVesselThresholdRangeWidgetChanged(self):
        self.updateParameterNodeFromGUI()
 
@@ -694,10 +682,6 @@ class LungCTSegmenterWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       self.ui.VolumeRenderingShiftSliderWidget.value = self.VolumeRenderingShift
       self.ui.LungThresholdRangeWidget.minimumValue = self.lungThresholdMin
       self.ui.LungThresholdRangeWidget.maximumValue = self.lungThresholdMax 
-      self.ui.AirwayThresholdRangeWidget.minimumValue = self.airwayThresholdMin
-      self.ui.AirwayThresholdRangeWidget.maximumValue = self.airwayThresholdMax
-      self.ui.VesselThresholdRangeWidget.minimumValue = self.vesselThresholdMin
-      self.ui.VesselThresholdRangeWidget.maximumValue = self.vesselThresholdMax
 
       self.updateFiducialObservations(self._rightLungFiducials, self.logic.rightLungFiducials)
       self.updateFiducialObservations(self._leftLungFiducials, self.logic.leftLungFiducials)
@@ -749,10 +733,6 @@ class LungCTSegmenterWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       settings.setValue("LungCtSegmenter/lungThresholdRangeMinimumValue", str(self.ui.LungThresholdRangeWidget.minimumValue))
       self.lungThresholdMax = self.ui.LungThresholdRangeWidget.maximumValue
       settings.setValue("LungCtSegmenter/lungThresholdRangeMaximumValue", str(self.ui.LungThresholdRangeWidget.maximumValue))
-      self.airwayThresholdMin = self.ui.AirwayThresholdRangeWidget.minimumValue
-      settings.setValue("LungCtSegmenter/airwayThresholdRangeMinimumValue", str(self.ui.AirwayThresholdRangeWidget.minimumValue))
-      self.airwayThresholdMax = self.ui.AirwayThresholdRangeWidget.maximumValue
-      settings.setValue("LungCtSegmenter/airwayThresholdRangeMaximumValue", str(self.ui.AirwayThresholdRangeWidget.maximumValue))
       self.vesselThresholdMin = self.ui.VesselThresholdRangeWidget.minimumValue
       settings.setValue("LungCtSegmenter/vesselThresholdRangeMinimumValue", str(self.ui.VesselThresholdRangeWidget.minimumValue))
       self.vesselThresholdMax = self.ui.VesselThresholdRangeWidget.maximumValue
@@ -965,8 +945,6 @@ class LungCTSegmenterWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
           self.logic.lungThresholdMin = self.lungThresholdMin
           self.logic.lungThresholdMax = self.lungThresholdMax 
-          self.logic.airwayThresholdMin = self.airwayThresholdMin
-          self.logic.airwayThresholdMax = self.airwayThresholdMax
           self.logic.vesselThresholdMin = self.vesselThresholdMin
           self.logic.vesselThresholdMax = self.vesselThresholdMax
 
@@ -1286,10 +1264,6 @@ class LungCTSegmenterLogic(ScriptedLoadableModuleLogic):
           parameterNode.SetParameter("LungThresholdMin", "-1500")
         if not parameterNode.GetParameter("LungThresholdMax"):
           parameterNode.SetParameter("LungThresholdMax", "-400")
-        if not parameterNode.GetParameter("AirwayThresholdMin"):
-          parameterNode.SetParameter("AirwayThresholdMin", "-1500")
-        if not parameterNode.GetParameter("AirwayThresholdMax"):
-          parameterNode.SetParameter("AirwayThresholdMax", "-850")
         if not parameterNode.GetParameter("VesselThresholdMin"):
           parameterNode.SetParameter("VesselThresholdMin", "0")
         if not parameterNode.GetParameter("VesselThresholdMax"):
@@ -1316,24 +1290,6 @@ class LungCTSegmenterLogic(ScriptedLoadableModuleLogic):
     @lungThresholdMax.setter
     def lungThresholdMax(self, value):
         self.getParameterNode().SetParameter("LungThresholdMax", str(value))
-
-    @property
-    def airwayThresholdMin(self):
-        thresholdStr = self.getParameterNode().GetParameter("AirwayThresholdMin")
-        return float(thresholdStr) if thresholdStr else -1500
-
-    @airwayThresholdMin.setter
-    def airwayThresholdMin(self, value):
-        self.getParameterNode().SetParameter("AirwayThresholdMin", str(value))
-
-    @property
-    def airwayThresholdMax(self):
-        thresholdStr = self.getParameterNode().GetParameter("AirwayThresholdMax")
-        return float(thresholdStr) if thresholdStr else -850
-
-    @airwayThresholdMax.setter
-    def airwayThresholdMax(self, value):
-        self.getParameterNode().SetParameter("AirwayThresholdMax", str(value))
 
     @property
     def vesselThresholdMin(self):
@@ -2135,6 +2091,7 @@ class LungCTSegmenterLogic(ScriptedLoadableModuleLogic):
         import time
         startTime = time.time()
 
+
         if not self.useAI: 
             self.showStatusMessage('Finalize region growing...')
             # Ensure closed surface representation is not present (would slow down computations)
@@ -2547,7 +2504,6 @@ class LungCTSegmenterLogic(ScriptedLoadableModuleLogic):
                 slicer.util.errorDisplay("Please install 'SegmentEditorExtraEffects' extension using the extension manager.")
             else:
                 self.showStatusMessage('Airway segmentation ...')
-                scalarRange = self.inputVolume.GetImageData().GetScalarRange()
                 
                 # self.segmentEditorNode = self.segmentEditorWidget.mrmlSegmentEditorNode()
                 wasModified = self.outputSegmentation.StartModify()
@@ -2559,6 +2515,7 @@ class LungCTSegmenterLogic(ScriptedLoadableModuleLogic):
                     self.outputSegmentation.SetReferenceImageGeometryParameterFromVolumeNode(self.inputVolume)
                     self.segmentEditorWidget.setSourceVolumeNode(self.inputVolume)
 
+                scalarRange = self.inputVolume.GetImageData().GetScalarRange()
 
                 # Trigger display update
                 self.outputSegmentation.Modified()
@@ -2575,8 +2532,7 @@ class LungCTSegmenterLogic(ScriptedLoadableModuleLogic):
                 effect.setParameter("HistogramSetLower","LOWER")
                 effect.setParameter("HistogramSetUpper","UPPER")
                 effect.setParameter("MaximumThreshold",self.medianLungs)
-                # effect.setParameter("MaximumThreshold",self.airwayThresholdMax)
-                effect.setParameter("MinimumThreshold",self.airwayThresholdMin)
+                effect.setParameter("MinimumThreshold",scalarRange[0])
                                 
                 if self.airwaySegmentationDetailLevel == "low detail":
                     effect.setParameter("MinimumDiameterMm","3")
@@ -3048,7 +3004,7 @@ class LungCTSegmenterTest(ScriptedLoadableModuleTest):
 
         # Logic testing is disabled by default to not overload automatic build machines (pytorch is a huge package and computation
         # on CPU takes 5-10 minutes). Set testLogic to True to enable testing.
-        testLogic = False
+        testLogic = True
         if testLogic:
 
             # Test the module logic

--- a/LungCTSegmenter/Resources/UI/LungCTSegmenter.ui
+++ b/LungCTSegmenter/Resources/UI/LungCTSegmenter.ui
@@ -642,45 +642,13 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>Airway thresholds: </string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="ctkRangeWidget" name="AirwayThresholdRangeWidget">
-        <property name="toolTip">
-         <string>This parameter equals 'threshold range' in the airway segmentation 'Local Threshold-&gt; Growcut' algorithm. It is only effective if 'Airway segmentation' is enabled.  It is recommended to leave the lower threshold slider -&gt;  full left.  If airway segment is incomplete or leaking, modify the upper threshold slider slightly and stepwise (+/- 30). Re-run the segmentation by pressing 'Apply' to see any effect. See 'detail' dropdown menu (above) for additional airway segmentation effects. </string>
-        </property>
-        <property name="singleStep">
-         <double>1.000000000000000</double>
-        </property>
-        <property name="minimum">
-         <double>-1500.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>0.000000000000000</double>
-        </property>
-        <property name="minimumValue">
-         <double>-1500.000000000000000</double>
-        </property>
-        <property name="maximumValue">
-         <double>-850.000000000000000</double>
-        </property>
-        <property name="tickInterval">
-         <double>0.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
          <string>Vessel thresholds:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="1" column="1">
        <widget class="ctkRangeWidget" name="VesselThresholdRangeWidget">
         <property name="toolTip">
          <string>Set vessel thresholds depending on the vascular contrast medium used in your input volume. </string>
@@ -699,14 +667,14 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="label_9">
         <property name="text">
          <string>Volume rendering Shift</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="2" column="1">
        <widget class="ctkSliderWidget" name="VolumeRenderingShiftSliderWidget">
         <property name="minimum">
          <double>-300.000000000000000</double>
@@ -719,7 +687,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="3" column="0">
        <widget class="QPushButton" name="setDefaultButton">
         <property name="toolTip">
          <string>Reset lung range and airway range to default values.</string>
@@ -729,7 +697,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="3" column="1">
        <widget class="QPushButton" name="updateIntensityButton">
         <property name="toolTip">
          <string>Update current segmentation preview after lung intensity range changes</string>
@@ -739,7 +707,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
+      <item row="4" column="0">
        <widget class="QCheckBox" name="saveFiducialsCheckBox">
         <property name="toolTip">
          <string>Save markups, created during mask segmentation, in current data directory. This happens when pressing &quot;Apply&quot;. Use &quot;Load last markups&quot; checkbox for loading the markups again after &quot;Cancel/Reset&quot; and &quot;Start&quot;. </string>
@@ -749,7 +717,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item row="5" column="0">
        <widget class="QCheckBox" name="detailedMasksCheckBox">
         <property name="toolTip">
          <string>Choose this if you want to create  ventral, dorsal, upper, middle and lower lung masks. Slows down the procedure.  </string>
@@ -759,37 +727,7 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="0">
-       <widget class="QCheckBox" name="shrinkMasksCheckBox">
-        <property name="toolTip">
-         <string>This option shrinks the lung masks to avoid artifacts from pleura and pericardium. </string>
-        </property>
-        <property name="text">
-         <string>Auto shrink masks (1 mm)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="0">
-       <widget class="QCheckBox" name="fastCheckBox">
-        <property name="toolTip">
-         <string>Try this on systems with low GPU memory (&lt; 7GB)</string>
-        </property>
-        <property name="text">
-         <string>Totalsegmentator: --fast option</string>
-        </property>
-       </widget>
-      </item>
-      <item row="10" column="0">
-       <widget class="QCheckBox" name="smoothLungsCheckBox">
-        <property name="toolTip">
-         <string>Smooth AI generated lungs and lobes. Prolongs processing and is on by default.  </string>
-        </property>
-        <property name="text">
-         <string>Smooth lungs and lobes</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
+      <item row="6" column="0">
        <widget class="QCheckBox" name="calibrateDataCheckBox">
         <property name="enabled">
          <bool>true</bool>
@@ -799,6 +737,36 @@
         </property>
         <property name="text">
          <string>CT calibration</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QCheckBox" name="shrinkMasksCheckBox">
+        <property name="toolTip">
+         <string>This option shrinks the lung masks to avoid artifacts from pleura and pericardium. </string>
+        </property>
+        <property name="text">
+         <string>Auto shrink masks (1 mm)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QCheckBox" name="fastCheckBox">
+        <property name="toolTip">
+         <string>Try this on systems with low GPU memory (&lt; 7GB)</string>
+        </property>
+        <property name="text">
+         <string>Totalsegmentator: --fast option</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QCheckBox" name="smoothLungsCheckBox">
+        <property name="toolTip">
+         <string>Smooth AI generated lungs and lobes. Prolongs processing and is on by default.  </string>
+        </property>
+        <property name="text">
+         <string>Smooth lungs and lobes</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
In an attempt to standardize, finally, remove the airway threshold slider that controls the Local Threshold Grow Cut algorithm, add the median radiodensity of the right and left lung as the upper airway threshold parameter.

 


